### PR TITLE
UCBG-246: Fixing auth ref and term ref configuration

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/botgarden/tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/botgarden/tenant-bindings.delta.xml
@@ -99,7 +99,7 @@
                         </types:item>
                         <types:item xmlns:types="http://collectionspace.org/services/config/types">
                             <types:key>authRef</types:key>
-                            <types:value>taxonomicIdentGroupList/*/requestedBy</types:value>
+                            <types:value>requestedBy</types:value>
                         </types:item>                        
                         <types:item xmlns:types="http://collectionspace.org/services/config/types">
                             <types:key>authRef</types:key>


### PR DESCRIPTION
Amy -

Here are the complete changes to tenant-bindings.delta.xml. It's late, and I haven't yet tested all the fields on the cataloging and taxon records in the UI to be sure this all works. I'll do that in the morning.

One slightly open issue: I found 4 fields commented out in tenant-bindings.delta.xml that appear in naturalhistory-procedure-loanout.xml. These are:
- transferGroupList/*/transferOrg
- transferGroupList/*/transferPerson
- transferGroupList/*/transferDirector
- returnGroupList/*/returnDetermination

Maybe these should be uncommented here. Better yet, perhaps, they could be commented out in naturalhistory-procedure-loanout.xml.

One additional app-layer config issue that I found, which might require fixing:
- assocConcept in local-collectionobject.xml is not assigned to any authority-vocabulary. Is this intended to override the setting in base-collectionobject.xml in some way? Is it ok to configure a field as autocomplete without tying it to an authority? Or is it in error?

Thanks!
Rick
