### PR TITLE
HM-19: Improved BC date range precision, added carbon dating support

### DIFF
--- a/services/structureddate/structureddate/src/main/antlr4/org/collectionspace/services/structureddate/antlr/StructuredDate.g4
+++ b/services/structureddate/structureddate/src/main/antlr4/org/collectionspace/services/structureddate/antlr/StructuredDate.g4
@@ -16,6 +16,7 @@ displayDate:           uncertainDate
 /* TODO: Need to decide what "before" and "after" actually mean
 |                      beforeOrAfterDate
 */
+|                      uncalibratedDate
 ;
 
 uncertainDate:         CIRCA certainDate ;
@@ -25,6 +26,8 @@ certainDate:           hyphenatedRange
 ;
 
 beforeOrAfterDate:     ( BEFORE | AFTER ) singleInterval ;
+
+uncalibratedDate:      numYear PLUSMINUS NUMBER YEARSSTRING? BP; 
 
 hyphenatedRange:       singleInterval ( HYPHEN | DASH ) singleInterval
 |                      nthCenturyRange
@@ -125,7 +128,7 @@ num:                   NUMBER ;
 /*
  * Lexer rules
  */
-
+PLUSMINUS:      '±' | '+/-' ;
 WS:             [ \t\r\n]+ -> skip;
 CIRCA:          ('c' | 'ca') DOT? | 'circa' ;
 SPRING:         'spring' | 'spr' ;
@@ -148,8 +151,9 @@ CENTURY:        'century' ;
 MILLENNIUM:     'millennium' ;
 MONTH:          'january' | 'february' | 'march' | 'april' | 'may' | 'june' | 'july' | 'august' | 'september' | 'october' | 'november' | 'december' ;
 SHORTMONTH:     'jan' | 'feb' | 'mar' | 'apr' | 'jun' | 'jul' | 'aug' | 'sep' | 'sept' | 'oct' | 'nov' | 'dec' ;
-BC:             'bc' | 'bce' |  'b.c.' | 'b.c.e.' ;
+BC:             'bc' | 'bce' |  'b.c.' | 'b.c.e.';
 AD:             'ad' | 'a.d.' | 'ce' | 'c.e.';
+BP:             'bp' | 'b.p.' | 'b.p' ;
 NTHSTR:         [0-9]*? ([0456789] 'th' | '1st' | '2nd' | '3rd' | '11th' | '12th' | '13th') ;
 HUNDREDS:       [0-9]*? '00' '\''? 's';
 TENS:           [0-9]*? '0' '\''? 's';
@@ -160,5 +164,7 @@ DASH:           [—–] ; /* EM DASH, EN DASH */
 SLASH:          '/' ;
 DOT:            '.' ;
 QUESTION:       '?' ;
-STRING:         [a-z]+ ;
 OTHER:          . ;
+UNKNOWN:        'unknown';
+YEARSSTRING:    'years' | 'year';
+STRING:         [a-z]+ ;

--- a/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/DateUtils.java
+++ b/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/DateUtils.java
@@ -10,6 +10,7 @@ import org.joda.time.Years;
 import org.joda.time.chrono.GJChronology;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.LocalDate;
 
 public class DateUtils {
 	private static final DateTimeFormatter monthFormatter = DateTimeFormat.forPattern("MMMM");
@@ -1063,7 +1064,8 @@ public class DateUtils {
 	 */
 	public static Date getEarliestBeforeDate(Date startDate, Date endDate) {
 		// TODO
-		return null;
+		// Return an empty date to be used in before date cases
+		return new Date();
 		
 		/*
 		// This algorithm is inherited from the XDB fuzzydate parser,
@@ -1106,7 +1108,7 @@ public class DateUtils {
 	
 	/**
 	 * Calculates the latest date that may be considered to be "after"
-	 * a given date range.
+	 * a given date range. We define "after" as the current date.
 	 * 
 	 * @param startDate The first date in the range
 	 * @param endDate   The last date in the range
@@ -1114,7 +1116,16 @@ public class DateUtils {
 	 */
 	public static Date getLatestAfterDate(Date startDate, Date endDate) {
 		// TODO
-		return null;
+		return getCurrentDate();
+
+	}
+
+	public static Date getCurrentDate() {
+		LocalDate localDate = new LocalDate();
+		Integer year = (Integer) localDate.getYear();
+		Integer month = (Integer) localDate.getMonthOfYear();
+		Integer dayOfMonth = (Integer) localDate.getDayOfMonth();
+		return new Date(year, month, dayOfMonth, Date.DEFAULT_ERA);
 	}
 
 	public static int getYearsBetween(Date startDate, Date endDate) {

--- a/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
+++ b/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
@@ -111,8 +111,8 @@ public class ANTLRStructuredDateEvaluator extends StructuredDateBaseListener imp
 		result.setDisplayDate(displayDate);
 
 		// Instantiate a parser from the lowercased display date, so that parsing will be
-		// case insensitive.
-		ANTLRInputStream inputStream = new ANTLRInputStream(displayDate.toLowerCase());
+		// case insensitive. Also remove commas so that numbers with commas are parsed correctly
+		ANTLRInputStream inputStream = new ANTLRInputStream(displayDate.toLowerCase().replaceAll(",", ""));
 		StructuredDateLexer lexer = new StructuredDateLexer(inputStream);
 		CommonTokenStream tokenStream = new CommonTokenStream(lexer);
 		StructuredDateParser parser = new StructuredDateParser(tokenStream);

--- a/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
+++ b/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
@@ -212,6 +212,26 @@ public class ANTLRStructuredDateEvaluator extends StructuredDateBaseListener imp
 		int earliestInterval = DateUtils.getCircaIntervalYears(earliestDate.getYear(), earliestDate.getEra());
 		int latestInterval = DateUtils.getCircaIntervalYears(latestDate.getYear(), latestDate.getEra());
 
+		if (earliestDate.getEra() == Era.BCE && latestDate.getEra() == Era.BCE) {
+			// Improved precision for BC dates
+			if ((latestDate.getMonth() == 12 && latestDate.getDay() == 31) &&
+				(earliestDate.getMonth() == 1 && earliestDate.getDay() == 1)) {
+				int year = earliestDate.getYear(); // Should be the same year...
+				int interval = 0;
+
+				if (year % 1000 == 0) {
+					interval = 500;
+				} else if (year % 100 == 0) {
+					interval = 50;
+				} else if (year % 10 == 0) {
+					interval = 10;
+				} else if (year % 10 > 0 && year % 10 < 10) {
+					interval = 5;
+				}
+				earliestInterval = interval;
+				latestInterval = interval;
+			}
+		}
 		// Express the circa interval as a qualifier.
 
 		// stack.push(earliestDate.withQualifier(QualifierType.MINUS, earliestInterval, QualifierUnit.YEARS));

--- a/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
+++ b/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
@@ -285,6 +285,26 @@ public class ANTLRStructuredDateEvaluator extends StructuredDateBaseListener imp
 			((DeferredDate) latestEndDate).resolveDate();
 		}
 
+		// Check if they are reversed
+		if (latestEndDate.getEra() == Era.BCE && earliestStartDate.getEra() == Era.BCE) {
+			if (earliestStartDate.getYear() < latestEndDate.getYear()) {
+				Date tmp = earliestStartDate;
+				earliestStartDate = latestEndDate;
+				latestEndDate = tmp;
+
+				// This is probably bad technique, but right now, if the month and days were calculated
+				// Chances are that the EarliestStart date has the LatestStart date
+				// And the latestEnd date has the earliestEnd date. So we set them accordingly.
+				if ((earliestStartDate.getMonth() == 12 && earliestStartDate.getDay() == 31) &&
+					(latestEndDate.getMonth() == 1 && latestEndDate.getDay() == 1)) {
+						earliestStartDate.setMonth(1);
+						earliestStartDate.setDay(1);
+						latestEndDate.setMonth(12);
+						latestEndDate.setDay(31);
+				}
+			}
+		}
+
 		stack.push(earliestStartDate);
 		stack.push(latestEndDate);
 	}

--- a/services/structureddate/structureddate/src/test/resources/test-dates.yaml
+++ b/services/structureddate/structureddate/src/test/resources/test-dates.yaml
@@ -1069,8 +1069,8 @@
   #                                      latestDate:         [  10, 12, 31, BCE, null, PLUS,  106, YEARS]
 
   'Circa 10 BC':                         # uncertainDate, year - calculating the uncertainty into the year field
-                                         earliestSingleDate: [ 115,  1,  1, BCE]
-                                         latestDate:         [  96, 12, 31, CE]
+                                         earliestSingleDate: [ 20,  1,  1, BCE]
+                                         latestDate:         [  1, 12, 31, CE]
 
   # 'Circa 10':                          # uncertainDate, year - using qualifier/value/unit fields
   #                                      earliestSingleDate: [  10,  1,  1, CE, null, MINUS, 105, YEARS]
@@ -1134,13 +1134,29 @@
                                          earliestSingleDate: [5580,  1, 1, BCE]
                                          latestDate:         [5460,  12, 31, BCE]
 
-  "5,580 - 5,460 BC":                      #Calibrated date with commas and spaces
+  "5,580 - 5,460 BC":                    #Calibrated date with commas and spaces
                                          earliestSingleDate: [5580,  1, 1, BCE]
                                          latestDate:         [5460,  12, 31, BCE]
 
   "5460-5580 BC":                        #Calibrated date with dates reversed
                                          earliestSingleDate: [5580,  1, 1, BCE]
                                          latestDate:         [5460,  12, 31, BCE]
+
+  "c. 69 BC":                            # Circa date, ± 10 years
+                                         earliestSingleDate: [74, 1, 1, BCE]
+                                         latestDate:         [64, 12, 31, BCE]
+
+  "ca. 60 BC":                           # Circa date, ± 5 years
+                                         earliestSingleDate: [70, 1, 1, BCE]
+                                         latestDate:         [50, 12, 31, BCE]
+
+  "circa 200 BC":                        # Circa date, ± 50 years
+                                         earliestSingleDate: [250, 1, 1, BCE]
+                                         latestDate:         [150, 12, 31, BCE]
+
+  "circa 1000 BC":                       # Circa date, ± 500 years
+                                         earliestSingleDate: [1500, 1, 1, BCE]
+                                         latestDate:         [500, 12, 31, BCE]
 # -------------------------------------------------------------------------------------------------------
 # Invalid dates
 # -------------------------------------------------------------------------------------------------------

--- a/services/structureddate/structureddate/src/test/resources/test-dates.yaml
+++ b/services/structureddate/structureddate/src/test/resources/test-dates.yaml
@@ -1106,6 +1106,25 @@
   "3/4/2000?":                           # oneDisplayDate - with question mark
                                          earliestSingleDate: [2000,  3,  4, CE]
 
+  "1200±50 BP":                          # Uncalibrated date with ± symbol, with CE
+                                         earliestSingleDate: [768,  1, 1, CE]
+                                         latestDate:         [868,  12, 31, CE]
+
+  "3100 +/- 150 BP":                    # Uncalibrated date with +/- instead of ± symbol
+                                         earliestSingleDate: [1232,  1, 1, BCE]
+                                         latestDate:         [932,  12, 31, BCE]
+
+  "3100+/-150 BP":                      # Uncalibrated date with +/- instead of ± symbol, no spaces
+                                         earliestSingleDate: [1232,  1, 1, BCE]
+                                         latestDate:         [932,  12, 31, BCE]
+
+  "3100+/-150 years BP":                 # Uncalibrated date with 'years' in it
+                                         earliestSingleDate: [1232,  1, 1, BCE]
+                                         latestDate:         [932,  12, 31, BCE]
+
+  "2000±100 BP":                         # Uncalibrated date with BCE and AD mix
+                                         earliestSingleDate: [82,  1, 1, BCE]
+                                         latestDate:         [118,  12, 31, CE]
 # -------------------------------------------------------------------------------------------------------
 # Invalid dates
 # -------------------------------------------------------------------------------------------------------

--- a/services/structureddate/structureddate/src/test/resources/test-dates.yaml
+++ b/services/structureddate/structureddate/src/test/resources/test-dates.yaml
@@ -925,8 +925,8 @@
                                          latestDate:         [2013,  4,  5, CE]
 
   '5/3/1962-4/5/2013 BC':                # hyphenatedRange, date
-                                         earliestSingleDate: [1962,  5,  3, BCE]
-                                         latestDate:         [2013,  4,  5, BCE]
+                                         earliestSingleDate:  [2013,  4,  5, BCE]
+                                         latestDate:          [1962,  5,  3, BCE]
 
   '5/3/1962 BC-4/5/2013':                # hyphenatedRange, date
                                          earliestSingleDate: [1962,  5,  3, BCE]
@@ -1122,13 +1122,25 @@
                                          earliestSingleDate: [1232,  1, 1, BCE]
                                          latestDate:         [932,  12, 31, BCE]
 
-  "3,100+/-150 years BP":                 # Uncalibrated date with 'years' in it
+  "3,100+/-150 years BP":                 # Uncalibrated date with 'years' in it as well as with a comma
                                          earliestSingleDate: [1232,  1, 1, BCE]
                                          latestDate:         [932,  12, 31, BCE]
 
   "2000±100 BP":                         # Uncalibrated date with BCE and AD mix
                                          earliestSingleDate: [82,  1, 1, BCE]
                                          latestDate:         [118,  12, 31, CE]
+
+  "5,580-5,460 BC":                      #Calibrated date with commas
+                                         earliestSingleDate: [5580,  1, 1, BCE]
+                                         latestDate:         [5460,  12, 31, BCE]
+
+  "5,580 - 5,460 BC":                      #Calibrated date with commas and spaces
+                                         earliestSingleDate: [5580,  1, 1, BCE]
+                                         latestDate:         [5460,  12, 31, BCE]
+
+  "5460-5580 BC":                        #Calibrated date with dates reversed
+                                         earliestSingleDate: [5580,  1, 1, BCE]
+                                         latestDate:         [5460,  12, 31, BCE]
 # -------------------------------------------------------------------------------------------------------
 # Invalid dates
 # -------------------------------------------------------------------------------------------------------

--- a/services/structureddate/structureddate/src/test/resources/test-dates.yaml
+++ b/services/structureddate/structureddate/src/test/resources/test-dates.yaml
@@ -1122,6 +1122,10 @@
                                          earliestSingleDate: [1232,  1, 1, BCE]
                                          latestDate:         [932,  12, 31, BCE]
 
+  "3,100+/-150 years BP":                 # Uncalibrated date with 'years' in it
+                                         earliestSingleDate: [1232,  1, 1, BCE]
+                                         latestDate:         [932,  12, 31, BCE]
+
   "2000±100 BP":                         # Uncalibrated date with BCE and AD mix
                                          earliestSingleDate: [82,  1, 1, BCE]
                                          latestDate:         [118,  12, 31, CE]


### PR DESCRIPTION
Added: 
- Carbon Date support (ex: 3000 ± 50 BP) 
- Ability to comma-separate years (ex: 5,000 and 5,000,000)
- Improved precision of Circa dates
- Calibrated dates can now be in the wrong order. Ex: 540 - 300 BC and 300 - 540 BC will produce same correct output.