### PR TITLE
CC-570, CC-693: widen field, fix deprecated displayname col

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/ucjepsloan.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/ucjepsloan.jrxml
@@ -25,7 +25,7 @@
     specialconditionsofloan,
     loanoutnote,
     lnh.numlent,
-    org.displayname,
+    getdispl(org.refname) as displayname,
     org.id,
     geog.item geography,
     case
@@ -201,7 +201,7 @@ URL: http://ucjeps.berkeley.edu]]></text>
 				<textFieldExpression><![CDATA[$F{addresscountry}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement x="140" y="258" width="191" height="20"/>
+				<reportElement x="140" y="258" width="371" height="20"/>
 				<textElement>
 					<font isBold="true"/>
 				</textElement>


### PR DESCRIPTION
widen field width for borrowerscontact from 191 to 371 so name is not truncated.
replace reference to deprecated displayname column in organizations_common table to use getdispl(refname) instead.