### PR TITLE
CC-1019: Add group title; update resource record

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/ucbgAccessionGroupReport.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/ucbgAccessionGroupReport.jrxml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.6.0.final using JasperReports Library version 6.6.0  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="object" language="groovy" pageWidth="595" pageHeight="842" columnWidth="523" leftMargin="36" rightMargin="36" topMargin="36" bottomMargin="36" uuid="66bea5cf-f33a-4c96-b75b-cc62a61ba2f7">
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
@@ -7,12 +8,17 @@
 	<style name="SubTitle" forecolor="#666666" fontName="SansSerif" fontSize="18"/>
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
-	<parameter name="tenantid" class="java.lang.String" isForPrompting="false">
-		<defaultValueExpression><![CDATA[35]]></defaultValueExpression>
-	</parameter>
 	<parameter name="csid" class="java.lang.String">
-		<defaultValueExpression><![CDATA["64d89988-dcde-467c-a91d"]]></defaultValueExpression>
+		<parameterDescription><![CDATA[Single record csid]]></parameterDescription>
 	</parameter>
+	<parameter name="groupcsid" class="java.lang.String">
+		<parameterDescription><![CDATA[Group procedure csid]]></parameterDescription>
+	</parameter>
+	<parameter name="reportcsid" class="java.lang.String">
+		<parameterDescription><![CDATA[CSID passed to query, coalesce(csid, groupcsid, "64d89988-dcde-467c-a91d")]]></parameterDescription>
+		<defaultValueExpression><![CDATA[$P{csid}!=null?$P{csid}:($P{groupcsid}!=null?$P{groupcsid}:"64d89988-dcde-467c-a91d")]]></defaultValueExpression>
+	</parameter>
+	<parameter name="grouptitle" class="java.lang.String"/>
 	<queryString>
 		<![CDATA[select g.title groupTitle,
 g.scopeNote, -- iReport has a checkbox for handling nulls (since they print the word null for some silly reason)
@@ -90,8 +96,7 @@ left outer join structureddategroup sdg on (sdg.id = hfcdg.id)
 left outer join collectionobjects_common_comments com on (co1.id = com.id and com.pos = 0)
 
 where misc.lifecyclestate <> 'deleted'
-AND core.tenantid=$P{tenantid}
-AND h1.name=$P{csid}
+AND h1.name=$P{reportcsid}
 
 order by objectNumber]]>
 	</queryString>
@@ -118,34 +123,34 @@ order by objectNumber]]>
 		<band splitType="Stretch"/>
 	</background>
 	<title>
-		<band height="25" splitType="Stretch">
+		<band height="50" splitType="Stretch">
 			<staticText>
-				<reportElement uuid="b8096fe7-6f34-4d5b-ab4b-fbfbe61a5a81" x="-1" y="0" width="115" height="20"/>
-				<textElement>
-					<font size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Accession Report]]></text>
-			</staticText>
-			<staticText>
-				<reportElement uuid="31769d39-6dee-483f-980e-e4002954e234" x="151" y="0" width="216" height="20"/>
-				<textElement textAlignment="Center">
+				<reportElement x="0" y="0" width="216" height="20" uuid="31769d39-6dee-483f-980e-e4002954e234"/>
+				<textElement textAlignment="Left">
 					<font size="10" isBold="false"/>
 				</textElement>
 				<text><![CDATA[UC Botanical Garden at Berkeley]]></text>
 			</staticText>
-			<textField pattern="dd-MMM-yyyy">
-				<reportElement uuid="a22ffab7-1422-4871-ba71-8185034df7ab" style="Column header" x="378" y="0" width="145" height="20" forecolor="#000000"/>
-				<textElement textAlignment="Right">
-					<font fontName="SansSerif" size="10" isBold="false"/>
+			<textField isStretchWithOverflow="true" evaluationTime="Report">
+				<reportElement x="0" y="25" width="523" height="20" uuid="e4fca62f-0135-4808-b859-4156bcccf05d"/>
+				<textElement textAlignment="Center">
+					<font size="12" isBold="true" isItalic="true"/>
 				</textElement>
-				<textFieldExpression><![CDATA[new java.util.Date()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{grouptitle}]]></textFieldExpression>
 			</textField>
+			<staticText>
+				<reportElement x="307" y="0" width="216" height="20" uuid="c1554c20-6709-4322-8295-661dd90a6881"/>
+				<textElement textAlignment="Right">
+					<font size="10" isBold="false"/>
+				</textElement>
+				<text><![CDATA[Accession Group Report]]></text>
+			</staticText>
 		</band>
 	</title>
 	<pageHeader>
 		<band height="4" splitType="Stretch">
 			<line>
-				<reportElement uuid="9ce54e17-7ce5-4f16-8149-b791ccfae97f" positionType="FixRelativeToBottom" x="0" y="1" width="520" height="1"/>
+				<reportElement positionType="FixRelativeToBottom" x="-1" y="1" width="525" height="1" uuid="9ce54e17-7ce5-4f16-8149-b791ccfae97f"/>
 				<graphicElement>
 					<pen lineWidth="0.5" lineColor="#999999"/>
 				</graphicElement>
@@ -153,115 +158,123 @@ order by objectNumber]]>
 		</band>
 	</pageHeader>
 	<detail>
-		<band height="152" splitType="Prevent">
+		<band height="153" splitType="Prevent">
 			<textField isStretchWithOverflow="true">
-				<reportElement uuid="bbe8f461-b0e6-421d-8394-062a29521a35" style="Detail" stretchType="RelativeToBandHeight" x="2" y="43" width="75" height="15"/>
+				<reportElement style="Detail" stretchType="RelativeToBandHeight" x="2" y="43" width="75" height="15" uuid="bbe8f461-b0e6-421d-8394-062a29521a35"/>
 				<textElement>
 					<font fontName="SansSerif" size="10"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{objectnumber}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement uuid="c7ae9bc8-9117-4e17-a47a-9f1dc03421a9" stretchType="RelativeToBandHeight" x="81" y="43" width="231" height="15" isPrintWhenDetailOverflows="true"/>
+				<reportElement stretchType="RelativeToBandHeight" x="81" y="43" width="231" height="15" isPrintWhenDetailOverflows="true" uuid="c7ae9bc8-9117-4e17-a47a-9f1dc03421a9"/>
 				<textElement>
 					<font size="10"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{determination}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement uuid="eb4b71f2-b9ac-4a3b-92b0-41c4a718a208" stretchType="RelativeToBandHeight" x="323" y="43" width="129" height="15"/>
+				<reportElement stretchType="RelativeToBandHeight" x="323" y="43" width="129" height="15" uuid="eb4b71f2-b9ac-4a3b-92b0-41c4a718a208"/>
 				<textElement>
 					<font size="10"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{family}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement uuid="98f2a172-126b-42f5-8887-1f41cb31a909" x="2" y="84" width="53" height="15"/>
+				<reportElement x="2" y="84" width="53" height="15" uuid="98f2a172-126b-42f5-8887-1f41cb31a909"/>
 				<textElement>
 					<font size="10"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{deadflag}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement uuid="d82afdbc-c091-4d09-a320-bc56b9d4309d" x="81" y="83" width="442" height="15" isPrintWhenDetailOverflows="true"/>
+				<reportElement x="81" y="83" width="442" height="15" isPrintWhenDetailOverflows="true" uuid="d82afdbc-c091-4d09-a320-bc56b9d4309d"/>
 				<textElement>
 					<font size="10"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{locality}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement uuid="c5a0843c-0dd2-45e3-a088-59d8904d0b3b" x="2" y="2" width="72" height="15"/>
+				<reportElement x="2" y="2" width="72" height="15" uuid="c5a0843c-0dd2-45e3-a088-59d8904d0b3b"/>
 				<textElement>
 					<font size="10"/>
 				</textElement>
 				<text><![CDATA[Source: ]]></text>
 			</staticText>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement uuid="e01ff01e-4d09-433c-9b46-01723a70dc54" stretchType="RelativeToBandHeight" x="80" y="2" width="333" height="15" isPrintWhenDetailOverflows="true"/>
+				<reportElement stretchType="RelativeToBandHeight" x="80" y="2" width="333" height="15" isPrintWhenDetailOverflows="true" uuid="e01ff01e-4d09-433c-9b46-01723a70dc54"/>
 				<textElement>
 					<font size="10"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{source}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement uuid="4ffec893-00bf-4842-a9bf-a9c1bf51d883" stretchType="RelativeToBandHeight" x="81" y="22" width="332" height="15" isPrintWhenDetailOverflows="true"/>
+				<reportElement stretchType="RelativeToBandHeight" x="81" y="22" width="332" height="15" isPrintWhenDetailOverflows="true" uuid="4ffec893-00bf-4842-a9bf-a9c1bf51d883"/>
 				<textElement>
 					<font size="10"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{requestedby}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement uuid="e8fac3dd-8450-4709-a04c-1a9e51b3f686" x="2" y="22" width="72" height="15"/>
+				<reportElement x="2" y="22" width="72" height="15" uuid="e8fac3dd-8450-4709-a04c-1a9e51b3f686"/>
 				<textElement>
 					<font size="10"/>
 				</textElement>
 				<text><![CDATA[Requested by:]]></text>
 			</staticText>
 			<line>
-				<reportElement uuid="b3300dc5-710a-467f-87b0-c09d334b3140" positionType="Float" x="-1" y="150" width="520" height="1"/>
+				<reportElement positionType="Float" x="-1" y="152" width="525" height="1" uuid="b3300dc5-710a-467f-87b0-c09d334b3140"/>
 				<graphicElement>
 					<pen lineWidth="0.5" lineColor="#999999"/>
 				</graphicElement>
 			</line>
 			<textField pattern="dd-MMM-yyyy" isBlankWhenNull="true">
-				<reportElement uuid="3c45ed3a-a668-42fe-a915-9bd8852c7b8f" x="423" y="2" width="100" height="15"/>
+				<reportElement x="423" y="2" width="100" height="15" uuid="3c45ed3a-a668-42fe-a915-9bd8852c7b8f"/>
 				<textElement textAlignment="Right">
 					<font size="10"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{accessiondate}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true">
-				<reportElement uuid="ddc3003b-4af4-44b9-8ed5-1c5061d5fcc8" x="452" y="43" width="71" height="15"/>
+				<reportElement x="452" y="43" width="71" height="15" uuid="ddc3003b-4af4-44b9-8ed5-1c5061d5fcc8"/>
 				<textElement textAlignment="Right">
 					<font size="10"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{materialtype}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement uuid="8b62d4f4-c0bf-4ec5-bea4-9610c70f9cf4" stretchType="RelativeToBandHeight" x="81" y="105" width="442" height="15" isPrintWhenDetailOverflows="true"/>
+				<reportElement stretchType="RelativeToBandHeight" x="81" y="105" width="442" height="15" isPrintWhenDetailOverflows="true" uuid="8b62d4f4-c0bf-4ec5-bea4-9610c70f9cf4"/>
 				<textElement>
 					<font size="10"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{accessionnotes}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
-				<reportElement uuid="0cfd4d29-b7e7-41c5-af73-1ae3c1a70e39" x="2" y="64" width="53" height="15" isRemoveLineWhenBlank="true"/>
+				<reportElement x="2" y="64" width="53" height="15" isRemoveLineWhenBlank="true" uuid="0cfd4d29-b7e7-41c5-af73-1ae3c1a70e39"/>
 				<textElement>
 					<font size="10"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{rarestatus}.equals("rare")? "\"rare\"" : null]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement uuid="daab812a-daf5-426d-8ab9-4868f88279a4" x="81" y="64" width="442" height="15" isPrintWhenDetailOverflows="true"/>
-				<textElement/>
+				<reportElement x="81" y="64" width="442" height="15" isPrintWhenDetailOverflows="true" uuid="daab812a-daf5-426d-8ab9-4868f88279a4"/>
 				<textFieldExpression><![CDATA[$F{collectioninfo}]]></textFieldExpression>
 			</textField>
 		</band>
 	</detail>
 	<pageFooter>
-		<band height="20" splitType="Stretch"/>
+		<band height="20" splitType="Stretch">
+			<textField pattern="dd-MMM-yyyy">
+				<reportElement style="Column header" x="378" y="2" width="145" height="16" forecolor="#000000" uuid="a22ffab7-1422-4871-ba71-8185034df7ab"/>
+				<textElement textAlignment="Right">
+					<font fontName="SansSerif" size="10" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[new java.util.Date()]]></textFieldExpression>
+			</textField>
+		</band>
 	</pageFooter>
 	<summary>
 		<band splitType="Stretch"/>
 	</summary>
 </jasperReport>
+

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/ucbgAccessionGroupReport.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/ucbgAccessionGroupReport.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
-    <name>Accession Report</name>
+    <name>Accession Group Report</name>
     <notes></notes>
     <forDocTypes>
       <forDocType>Group</forDocType>
     </forDocTypes>
     <supportsSingleDoc>true</supportsSingleDoc>
     <supportsDocList>false</supportsDocList>
-    <supportsGroup>false</supportsGroup>
-    <supportsNoContext>true</supportsNoContext>
+    <supportsGroup>true</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
     <filename>ucbgAccessionGroupReport.jasper</filename>
     <outputMIME>application/pdf</outputMIME>
     <supportsParams>false</supportsParams>


### PR DESCRIPTION
ucbgAccessionGroupReport.jrxml
 - Add group title to the report.
 - Revise position of objects in report's Title and Footer bands.
 - Remove tenantid references.
 - Revise report parameters to allow for group and single record contexts.

ucbgAccessionGroupReport.xml
 - Update report name.
 - Allow only group and single record contexts (supportsGroup, supportsSingleDoc).