### PR TITLE
CC-1422: BOTGARDEN: add missing file to grant privs to reporters_botgarden

### DIFF
--- a/services/common/src/main/resources/db/postgresql/grant_botgarden_reporters_privileges.sql
+++ b/services/common/src/main/resources/db/postgresql/grant_botgarden_reporters_privileges.sql
@@ -1,0 +1,10 @@
+DO $$
+BEGIN
+   IF EXISTS (
+      SELECT *
+      FROM   pg_catalog.pg_group
+      WHERE  groname = 'reporters_botgarden') THEN
+
+      GRANT SELECT ON ALL TABLES IN SCHEMA public TO GROUP reporters_botgarden;
+   END IF;
+END $$;


### PR DESCRIPTION
Errors from missing script:
`Oct 28 15:11:37 cspace-qa-02.ist.berkeley.edu server[62203]: 2020-10-28 15:11:37,975 WARN  [localhost-startStop-1] [org.collectionspace.services.common.init.RunSqlScripts:212] Could not read resource from path db/postgresql/grant_botgarden_reporters_privileges.sql
Oct 28 15:11:37 cspace-qa-02.ist.berkeley.edu server[62203]: 2020-10-28 15:11:37,975 WARN  [localhost-startStop-1] [org.collectionspace.services.common.init.RunSqlScripts:90] Could not get contents of SQL script from resource db/postgresql/grant_botgarden_reporters_privileges.sql
Oct 28 15:11:37 cspace-qa-02.ist.berkeley.edu server[62203]: 2020-10-28 15:11:37,976 WARN  [localhost-startStop-1] [org.collectionspace.services.common.init.RunSqlScripts:91] Will not be able to perform tasks within the RunSqlScript init handler.`