### PR TITLE
CC-1615: Check in missing code changes to ucb_6.0 branch

### DIFF
--- a/services/common/src/main/resources/db/postgresql/tenants/pahma/create_pahma_getnagpra_function.sql
+++ b/services/common/src/main/resources/db/postgresql/tenants/pahma/create_pahma_getnagpra_function.sql
@@ -1,0 +1,154 @@
+/* Function gets PAHMA NAGPRA Repatriation Compliance data for a single collection object.
+ * Used in the pahmapahmaRepatriationNAGPRAdenorm.jrxml report.
+ * Must created TYPE nagpratype before creating this function.
+ *
+ * Usage:
+ *   select utils.getnagpra('2dbcbf18-4966-4178-9880-e81258568921')
+ *
+ *   select * from utils.getnagpra('2dbcbf18-4966-4178-9880-e81258568921')
+ *
+ *   select utils.getnagpra(id) from collectionobjects_common 
+ *   where id in ('8cbd1864-5212-44af-9d69-512829e5a3e3', '2dbcbf18-4966-4178-9880-e81258568921')
+ *
+ *   select (n).* from (
+ *       select utils.getnagpra(h.id) as n from hierarchy h
+ *       where h.name in ('27c11fff-d74c-45dc-949c', '8cea428c-d3a5-4093-bcdb')) x
+ *   order by (n).objectnumber, (n).pos
+ */
+
+-- DROP FUNCTION utils.getnagpra (cocid VARCHAR);
+
+CREATE OR REPLACE FUNCTION utils.getnagpra (cocid VARCHAR)
+RETURNS SETOF nagpratype
+AS
+$$
+
+DECLARE
+    updsql text;
+    t varchar[];
+    reptabs varchar[] := array[['collectionobjects_nagpra_nagprainventorynames', 'nagpraInventoryName']
+                             , ['collectionobjects_nagpra_nagpracategories', 'nagpraCategory']
+                             , ['collectionobjects_nagpra_graveassoccodes', 'graveAssocCode']
+                             , ['collectionobjects_nagpra_repatriationnotes', 'repatriationNote']
+                             , ['collectionobjects_nagpra_nagpraculturaldeterminations', 'nagpraCulturalDetermination']];
+
+BEGIN
+
+    DROP TABLE IF EXISTS getnagpra_temp;
+
+    -- create temp table for processed data
+    CREATE TEMP TABLE getnagpra_temp (
+        cocsid varchar,
+        coid varchar,
+        pos integer,
+        objectNumber varchar,
+        sortableObjectNumber varchar,
+        nagpraInventoryName varchar,
+        nagpraCategory varchar,
+        graveAssocCode varchar,
+        repatriationNote varchar,
+        nagpraCulturalDetermination varchar,
+        nagpraDetermCulture varchar,
+        nagpraDetermType varchar,
+        nagpraDetermBy varchar,
+        nagpraDetermNote varchar,
+        nagpraReportFiled boolean,
+        nagpraReportFiledWith varchar,
+        nagpraReportFiledBy varchar,
+        nagpraReportFiledDate varchar,
+        nagpraReportFiledNote varchar,
+        reference varchar,
+        referenceNote varchar
+    );
+    
+    -- get unique positions for repeating fields/groups.
+    INSERT INTO getnagpra_temp (coid, pos)
+    SELECT id, pos FROM collectionobjects_nagpra_nagprainventorynames WHERE id = cocid
+    UNION
+    SELECT id, pos FROM collectionobjects_nagpra_nagpracategories WHERE id = cocid
+    UNION
+    SELECT id, pos FROM collectionobjects_nagpra_graveassoccodes WHERE id = cocid
+    UNION
+    SELECT id, pos FROM collectionobjects_nagpra_repatriationnotes WHERE id = cocid
+    UNION
+    SELECT id, pos FROM collectionobjects_nagpra_nagpraculturaldeterminations WHERE id = cocid
+    UNION
+    SELECT parentid, pos FROM hierarchy WHERE parentid = cocid AND primarytype = 'nagpraDetermGroup'
+    UNION
+    SELECT parentid, pos FROM hierarchy WHERE parentid = cocid AND primarytype = 'nagpraReportFiledGroup'
+    UNION
+    SELECT parentid, pos FROM hierarchy WHERE parentid = cocid AND primarytype = 'referenceGroup';
+
+    -- get csid, objectnumber, sortableobjectnumber for collection object record.
+    UPDATE getnagpra_temp SET cocsid = h.name FROM hierarchy h WHERE getnagpra_temp.coid = h.id;
+
+    UPDATE getnagpra_temp SET objectNumber = c.objectnumber FROM collectionobjects_common c WHERE getnagpra_temp.coid = c.id;
+
+    UPDATE getnagpra_temp SET sortableobjectnumber = c.sortableobjectnumber FROM collectionobjects_pahma c WHERE getnagpra_temp.coid = c.id;
+    
+    -- get displaynames for refnames in repeating fields
+    FOREACH t SLICE 1 IN ARRAY reptabs LOOP
+    
+        updsql := 'UPDATE getnagpra_temp SET '|| t[2] || ' = getdispl(n.item) ' ||
+                  'FROM ' || t[1] || ' n ' ||
+                  'WHERE getnagpra_temp.coid = n.id AND getnagpra_temp.pos = n.pos;';
+
+        --RAISE NOTICE 'updsql for %: %', t[1], updsql;
+
+        EXECUTE updsql;
+
+    END LOOP;
+    
+    -- get displaynames/notes for nagpraDetermGroup data.
+    UPDATE getnagpra_temp
+    SET nagpraDetermCulture = getdispl(n.nagpradetermculture),
+        nagpraDetermType = getdispl(n.nagpradetermtype),
+        nagpraDetermBy = getdispl(n.nagpradetermby),
+        nagpraDetermNote = n.nagpradetermnote
+    FROM nagpradetermgroup n join hierarchy h on (n.id = h.id)
+    WHERE getnagpra_temp.coid = h.parentid
+    AND h.primarytype = 'nagpraDetermGroup'
+    AND getnagpra_temp.pos = h.pos;
+
+    -- get displaynames/notes for nagpraReportFiledGroup data.
+    UPDATE getnagpra_temp
+    SET nagpraReportFiled = n.nagprareportfiled,
+        nagpraReportFiledWith = getdispl(n.nagprareportfiledwith),
+        nagpraReportFiledBy = getdispl(n.nagprareportfiledby),
+        nagpraReportFiledNote = n.nagprareportfilednote
+    FROM nagprareportfiledgroup n join hierarchy h on (n.id = h.id)
+    WHERE getnagpra_temp.coid = h.parentid
+    AND h.primarytype = 'nagpraReportFiledGroup'
+    AND getnagpra_temp.pos = h.pos;
+
+    -- get displaydate for nagpraReportFiledGroup data.
+    UPDATE getnagpra_temp
+    SET nagpraReportFiledDate = s.datedisplaydate
+    FROM hierarchy hn join hierarchy hs on (hn.id = hs.parentid)
+    join structureddategroup s on (hs.id = s.id)
+    WHERE getnagpra_temp.coid = hn.parentid
+    AND hs.name = 'nagpraReportFiledDate';
+
+    -- get displaynames/notes for referenceGroup data.
+    UPDATE getnagpra_temp
+    SET reference = getdispl(n.reference),
+        referenceNote = n.referencenote
+    FROM referencegroup n join hierarchy h on (n.id = h.id)
+    WHERE getnagpra_temp.coid = h.parentid
+    AND h.primarytype = 'referenceGroup'
+    AND getnagpra_temp.pos = h.pos;
+
+    -- convert returns and newlines to '\n'.
+    UPDATE getnagpra_temp SET
+        repatriationNote = regexp_replace(repatriationNote, E'[\n\r]+', '\n', 'g'), 
+        nagpraCulturalDetermination = regexp_replace(nagpraCulturalDetermination, E'[\n\r]+', '\n', 'g');
+
+    RETURN QUERY SELECT * FROM getnagpra_temp;
+
+END;
+
+$$
+LANGUAGE 'plpgsql'
+RETURNS NULL ON NULL INPUT;
+
+-- GRANT EXECUTE ON FUNCTION utils.getnagpra (cocid VARCHAR) TO PUBLIC;

--- a/services/common/src/main/resources/db/postgresql/tenants/pahma/create_pahma_nagpratype_type.sql
+++ b/services/common/src/main/resources/db/postgresql/tenants/pahma/create_pahma_nagpratype_type.sql
@@ -1,0 +1,29 @@
+-- Type used by utils.getnagpra(cocid varchar) to contain PAHMA NAGPRA Repatriation Compliance data
+-- for the pahmapahmaRepatriationNAGPRAdenorm.jrxml report.
+-- Must be created before function utils.getnagpra(cocid varchar).
+
+-- DROP TYPE nagpratype CASCADE;
+
+CREATE TYPE nagpratype AS (
+    cocsid varchar,
+    coid varchar,
+    pos integer,
+    objectNumber varchar,
+    sortableObjectNumber varchar,
+    nagpraInventoryName varchar,
+    nagpraCategory varchar,
+    graveAssocCode varchar,
+    repatriationNote varchar,
+    nagpraCulturalDetermination varchar,
+    nagpraDetermCulture varchar,
+    nagpraDetermType varchar,
+    nagpraDetermBy varchar,
+    nagpraDetermNote varchar,
+    nagpraReportFiled boolean,
+    nagpraReportFiledWith varchar,
+    nagpraReportFiledBy varchar,
+    nagpraReportFiledDate varchar,
+    nagpraReportFiledNote varchar,
+    reference varchar,
+    referenceNote varchar
+);

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/pahmaGroupNAGPRAexcel.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/pahmaGroupNAGPRAexcel.jrxml
@@ -136,17 +136,17 @@ LEFT OUTER JOIN hierarchy han ON (han.parentid=cc.id AND han.primarytype='pahmaA
 LEFT OUTER JOIN pahmaaltnumgroup ang ON (ang.id=han.id)
 LEFT OUTER JOIN hierarchy hpd ON (hpd.parentid=cc.id AND hpd.primarytype='structuredDateGroup' AND hpd.name='collectionobjects_common:objectProductionDateGroupList' AND (hpd.pos=0 or hpd.pos IS NULL))
 LEFT OUTER JOIN structureddategroup spd ON (spd.id=hpd.id)
-LEFT OUTER JOIN collectionobjects_pahma_pahmaobjectstatuslist oslAFIL ON (oslAFIL.id=cc.id AND oslAFIL.item IN (
+LEFT OUTER JOIN collectionobjects_pahma_pahmaobjectstatuslist oslAFIL ON (oslAFIL.id=cc.id AND getdispl(oslAFIL.item) IN (
 'culturally affiliated',
 'culturally unaffiliated'))
-LEFT OUTER JOIN collectionobjects_pahma_pahmaobjectstatuslist oslDISP ON (oslDISP.id=cc.id AND oslDISP.item IN (
+LEFT OUTER JOIN collectionobjects_pahma_pahmaobjectstatuslist oslDISP ON (oslDISP.id=cc.id AND getdispl(oslDISP.item) IN (
 'deaccessioned',
 'accessioned',
 '(unknown)',
 'partially deaccessioned',
 'recataloged',
 'partially recataloged'))
-LEFT OUTER JOIN collectionobjects_pahma_pahmaobjectstatuslist oslMODE ON (oslMODE.id=cc.id AND oslMODE.item IN (
+LEFT OUTER JOIN collectionobjects_pahma_pahmaobjectstatuslist oslMODE ON (oslMODE.id=cc.id AND getdispl(oslMODE.item) IN (
 'intended for repatriation',
 'pending repatriation',
 'intended for transfer',

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/pahmaRepatriationNAGPRAdenorm.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/pahmaRepatriationNAGPRAdenorm.jrxml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.6.0.final using JasperReports Library version 6.6.0  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="pahmaRepatriationNAGPRAdenorm" pageWidth="792" pageHeight="612" orientation="Landscape" columnWidth="752" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="89d4f477-fccc-4f23-acc1-8826e97fb360">
+	<property name="net.sf.jasperreports.print.keep.full.text" value="true"/>
+	<parameter name="csid" class="java.lang.String" isForPrompting="false">
+		<parameterDescription><![CDATA[Object CSID]]></parameterDescription>
+	</parameter>
+	<parameter name="groupcsid" class="java.lang.String" isForPrompting="false">
+		<parameterDescription><![CDATA[Group CSID]]></parameterDescription>
+	</parameter>
+	<parameter name="csidlist" class="java.lang.String" isForPrompting="false">
+		<parameterDescription><![CDATA[CSID List]]></parameterDescription>
+	</parameter>
+	<parameter name="objcsids" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{csidlist} != null ? ("'" + $P{csidlist}.replaceAll(",", "','") + "'") : ""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="wherecsid" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{csid} != null ? ("h.name = '" + $P{csid} + "'") : ""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="wheregroup" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{groupcsid} != null ? ("h.name IN (SELECT objectcsid FROM relations_common WHERE objectdocumenttype = 'CollectionObject' AND subjectcsid = '" + $P{groupcsid} + "')") : ""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="wherelist" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{csidlist} != null ? ("h.name IN (" + $P{objcsids} + ")") : ""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="whereclause" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{wherecsid} + $P{wheregroup} + $P{wherelist}]]></defaultValueExpression>
+	</parameter>
+	<queryString>
+		<![CDATA[select (n).* from (
+        select utils.getnagpra(h.id) as n 
+        from hierarchy h
+        where $P!{whereclause}) x
+        order by (n).objectnumber, (n).pos]]>
+	</queryString>
+	<field name="cocsid" class="java.lang.String"/>
+	<field name="coid" class="java.lang.String"/>
+	<field name="pos" class="java.lang.String"/>
+	<field name="objectNumber" class="java.lang.String"/>
+	<field name="sortableObjectNumber" class="java.lang.String"/>
+	<field name="nagpraInventoryName" class="java.lang.String"/>
+	<field name="nagpraCategory" class="java.lang.String"/>
+	<field name="graveAssocCode" class="java.lang.String"/>
+	<field name="repatriationNote" class="java.lang.String"/>
+	<field name="nagpraCulturalDetermination" class="java.lang.String"/>
+	<field name="nagpraDetermCulture" class="java.lang.String"/>
+	<field name="nagpraDetermType" class="java.lang.String"/>
+	<field name="nagpraDetermBy" class="java.lang.String"/>
+	<field name="nagpraDetermNote" class="java.lang.String"/>
+	<field name="nagpraReportFiled" class="java.lang.String"/>
+	<field name="nagpraReportFiledWith" class="java.lang.String"/>
+	<field name="nagpraReportFiledBy" class="java.lang.String"/>
+	<field name="nagpraReportFiledDate" class="java.lang.String"/>
+	<field name="nagpraReportFiledNote" class="java.lang.String"/>
+	<field name="reference" class="java.lang.String"/>
+	<field name="referenceNote" class="java.lang.String"/>
+	<columnHeader>
+		<band height="25">
+			<staticText>
+				<reportElement x="0" y="0" width="40" height="20" uuid="00c51817-97bb-4d5a-a2d1-ec6b4f147cd6"/>
+				<text><![CDATA[objectNumber]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="40" y="0" width="40" height="20" uuid="c8ef0e72-102a-496c-b929-5288c78b264e"/>
+				<text><![CDATA[sortableObjectNumber]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="80" y="0" width="20" height="20" uuid="29707f95-9134-408f-a447-c760bc9d974c"/>
+				<text><![CDATA[pos]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="100" y="0" width="40" height="20" uuid="694c362f-804c-4ca0-955e-695a06259348"/>
+				<text><![CDATA[nagpraInventoryName]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="140" y="0" width="40" height="20" uuid="40f2f8b3-e7d8-411a-913e-c8c41e11a3c3"/>
+				<text><![CDATA[nagpraCategory]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="180" y="0" width="40" height="20" uuid="8c434f76-68dd-47b1-83b0-d497dc706180"/>
+				<text><![CDATA[graveAssocCode]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="220" y="0" width="40" height="20" uuid="bd7a569e-601d-42ec-9c67-ec085b55af8a"/>
+				<text><![CDATA[repatriationNote]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="260" y="0" width="40" height="20" uuid="0b3ac1de-06bd-43f3-8065-4b37d2651918"/>
+				<text><![CDATA[nagpraCulturalDetermination]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="300" y="0" width="40" height="20" uuid="e38c8665-a53d-4266-97bd-2f10f6874470"/>
+				<text><![CDATA[nagpraDetermCulture]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="340" y="0" width="40" height="20" uuid="a566a5ba-014b-49fb-aabc-47e74f513333"/>
+				<text><![CDATA[nagpraDetermType]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="380" y="0" width="40" height="20" uuid="d6da8712-2369-46bf-a585-0aa8bc37e2ee"/>
+				<text><![CDATA[nagpraDetermBy]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="420" y="0" width="40" height="20" uuid="690ecaea-717d-477d-9bb2-f01ceb070a79"/>
+				<text><![CDATA[nagpraDetermNote]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="460" y="0" width="40" height="20" uuid="aaa8e503-9bcb-467f-a01f-8e216051d21e"/>
+				<text><![CDATA[nagpraReportFiled]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="500" y="0" width="40" height="20" uuid="6d70f647-f74f-409b-b06b-47c8638d1188"/>
+				<text><![CDATA[nagpraReportFiledWith]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="540" y="0" width="40" height="20" uuid="654567f0-df5e-446d-874a-768358d5635e"/>
+				<text><![CDATA[nagpraReportFiledBy]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="580" y="0" width="40" height="20" uuid="19460bdf-6783-46cb-a3df-683687ec7606"/>
+				<text><![CDATA[nagpraReportFiledDate]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="620" y="0" width="40" height="20" uuid="0e29cfcf-f052-451f-9f47-6562abcdd298"/>
+				<text><![CDATA[nagpraReportFiledNote]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="660" y="0" width="40" height="20" uuid="54962a4c-5a57-4aab-a396-b9ad26bfee6f"/>
+				<text><![CDATA[reference]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="700" y="0" width="40" height="20" uuid="07021367-1572-4831-a781-00cd33e3f2cf"/>
+				<text><![CDATA[referenceNote]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="35">
+			<textField>
+				<reportElement x="0" y="0" width="40" height="20" uuid="fe0bf036-3d96-4824-892d-9d073cc605e4"/>
+				<textFieldExpression><![CDATA[$F{objectNumber}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="40" y="0" width="40" height="20" uuid="1dfffdb8-4938-476b-a3af-db88613b071c"/>
+				<textFieldExpression><![CDATA[$F{sortableObjectNumber}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="100" y="0" width="40" height="20" uuid="bba1ddca-da0e-4cb9-a084-6d9baba32b88"/>
+				<textFieldExpression><![CDATA[$F{nagpraInventoryName}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="140" y="0" width="40" height="20" uuid="bb0ed6c3-29ac-406e-bc4d-3e2c44e76989"/>
+				<textFieldExpression><![CDATA[$F{nagpraCategory}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="180" y="0" width="40" height="20" uuid="d9e9a1e3-8224-4adb-8045-2255bbf8b128"/>
+				<textFieldExpression><![CDATA[$F{graveAssocCode}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="220" y="0" width="40" height="20" uuid="c1a85b94-f670-4997-ac74-1295b593ce2d"/>
+				<textFieldExpression><![CDATA[$F{repatriationNote}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="260" y="0" width="40" height="20" uuid="a5af0b32-5b5c-4773-8a5d-057b5f34b001"/>
+				<textFieldExpression><![CDATA[$F{nagpraCulturalDetermination}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="300" y="0" width="40" height="20" uuid="7b1d1415-d17f-47ea-a30f-1a6c20342af2"/>
+				<textFieldExpression><![CDATA[$F{nagpraDetermCulture}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="340" y="0" width="40" height="20" uuid="33f69289-0362-408e-8b3c-72e40fdfb038"/>
+				<textFieldExpression><![CDATA[$F{nagpraDetermType}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="380" y="0" width="40" height="20" uuid="e4a95ddf-de25-464f-a7f2-80b25bafe308"/>
+				<textFieldExpression><![CDATA[$F{nagpraDetermBy}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="420" y="0" width="40" height="20" uuid="260ef055-cbdb-44e2-90f4-55f647ce94ed"/>
+				<textFieldExpression><![CDATA[$F{nagpraDetermNote}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="460" y="0" width="40" height="20" uuid="7f05d035-397d-439c-a8f7-2927cb534b74"/>
+				<textFieldExpression><![CDATA[$F{nagpraReportFiled}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="500" y="0" width="40" height="20" uuid="9abe40c6-390b-448e-a8c3-cbb6802c3590"/>
+				<textFieldExpression><![CDATA[$F{nagpraReportFiledWith}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="540" y="0" width="40" height="20" uuid="8cc82072-7fe0-47a1-bd6d-8a8277304fd2"/>
+				<textFieldExpression><![CDATA[$F{nagpraReportFiledBy}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="580" y="0" width="40" height="20" uuid="a505412c-b126-4a97-ad16-eeddc3427af3"/>
+				<textFieldExpression><![CDATA[$F{nagpraReportFiledDate}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="620" y="0" width="40" height="20" uuid="220bfb90-70f0-4707-8829-291d104ecd69"/>
+				<textFieldExpression><![CDATA[$F{nagpraReportFiledNote}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="660" y="0" width="40" height="20" uuid="1838ba39-e9ee-47f2-a9a5-0cb0bd00efe5"/>
+				<textFieldExpression><![CDATA[$F{reference}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="700" y="0" width="40" height="20" uuid="a51e4296-9899-4102-ae4a-5334501259bc"/>
+				<textFieldExpression><![CDATA[$F{referenceNote}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="80" y="0" width="20" height="20" uuid="bac66fc2-f544-4e1a-b776-524f7c3fbd95"/>
+				<textFieldExpression><![CDATA[$F{pos}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/payloads/pahmaRepatriationNAGPRAdenorm.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/payloads/pahmaRepatriationNAGPRAdenorm.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document name="report">
+  <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
+    <name>Repatriation and NAGPRA Compliance (Denorm)</name>
+    <filename>pahmaRepatriationNAGPRAdenorm.jasper</filename>
+    <forDocTypes>
+      <forDocType>Group</forDocType>
+      <forDocType>CollectionObject</forDocType>
+    </forDocTypes>
+    <supportsSingleDoc>true</supportsSingleDoc>
+    <supportsDocList>true</supportsDocList>
+    <supportsGroup>true</supportsGroup>
+    <supportsNoContext>false</supportsNoContext>
+    <supportsParams>false</supportsParams>
+    <supportsOutputMIMEList>
+      <outputMIME>text/csv</outputMIME>
+    </supportsOutputMIMEList>
+    <outputMIME>text/csv</outputMIME>
+  </ns2:reports_common>
+</document>


### PR DESCRIPTION
Added the following changed files to ucb_6.0 branch, which have already been added to master:

PR-239; CC-1501: Add jrxml, payload, function, and type for Repatriation and NAGPRA Compliance (Denorm) report

- services/common/src/main/resources/db/postgresql/tenants/pahma/create_pahma_getnagpra_function.sql
- services/common/src/main/resources/db/postgresql/tenants/pahma/create_pahma_nagpratype_type.sql
- services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/pahmaRepatriationNAGPRAdenorm.jrxml
- services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/payloads/pahmaRepatriationNAGPRAdenorm.xml

PR-240; CC-1562: update report to get displayname from refname for S2D changes

- services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/pahmaGroupNAGPRAexcel.jrxml