### PR TITLE
CC-1463: Allow UoC by Approval Status report to run in single mode

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/bampfa/bampfaUOCbyApprovalStatus.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/bampfa/bampfaUOCbyApprovalStatus.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.6.0.final using JasperReports Library version 6.6.0  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="UOCApprovalStatus" pageWidth="612" pageHeight="792" whenNoDataType="NoDataSection" columnWidth="572" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="1da71959-7468-4c0d-8036-685691a34b6d">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="bampfaUOCbyApprovalStatus" pageWidth="612" pageHeight="792" whenNoDataType="NoDataSection" columnWidth="572" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="1da71959-7468-4c0d-8036-685691a34b6d">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
@@ -10,6 +10,10 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
+	<parameter name="csid" class="java.lang.String"/>
+	<parameter name="andClause" class="java.lang.String">
+		<defaultValueExpression><![CDATA[$P{csid} != null ? ("huoc.name = '" + $P{csid} + "'") : "1 = 1"]]></defaultValueExpression>
+	</parameter>
 	<parameter name="StartDate" class="java.lang.String">
 		<parameterDescription><![CDATA[StartDate]]></parameterDescription>
 		<defaultValueExpression><![CDATA["0001-01-01"]]></defaultValueExpression>
@@ -46,6 +50,7 @@ from uoc_common uoc
 join hierarchy huoc on (uoc.id = huoc.id)
 where get_uoc_authby(uoc.id, $P{AuthBy}, $P{AuthStatus}) is not null
 and coalesce(uoc.daterequested::timestamp at time zone 'US/Pacific' at time zone 'UTC', '0001-01-01') between to_date($P{StartDate}, 'yyyy-mm-dd') and to_date($P{EndDate}, 'yyyy-mm-dd')
+and $P!{andClause}
 order by uoc.daterequested, uoc.referencenumber]]>
 	</queryString>
 	<field name="authby" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/bampfa/payloads/bampfaUOCbyApprovalStatus.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/bampfa/payloads/bampfaUOCbyApprovalStatus.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Use of Collections by Approval Status</name>
-    <filename>bampfaUOCbyApprovalStatus.jrxml</filename>
+    <filename>bampfaUOCbyApprovalStatus.jasper</filename>
     <forDocTypes>
       <forDocType>Uoc</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/bampfa/payloads/bampfaUOCbyApprovalStatus.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/bampfa/payloads/bampfaUOCbyApprovalStatus.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Use of Collections by Approval Status</name>
-    <filename>ucbgUOCbyApprovalStatus.jrxml</filename>
+    <filename>bampfaUOCbyApprovalStatus.jrxml</filename>
     <forDocTypes>
       <forDocType>Uoc</forDocType>
     </forDocTypes>
@@ -18,4 +18,3 @@
     <notes>Lists Use of Collections requests with a value in the 'Authorized by' field, filtered by authorized by, authorization status, and/or date requested range. Displays the record number, title, requested date, completed date, authorization date, authorizer and authorization status. Available output formats: PDF, CSV, MS Word.</notes>
   </ns2:reports_common>
 </document>
-

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/bampfa/payloads/bampfaUOCbyRequesterObject.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/bampfa/payloads/bampfaUOCbyRequesterObject.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Use of Collections by Requester and/or Object</name>
-    <filename>ucbgUOCbyRequesterObject.jasper</filename>
+    <filename>bampfaUOCbyRequesterObject.jasper</filename>
     <forDocTypes>
       <forDocType>Uoc</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/cinefiles/cinefilesUOCbyApprovalStatus.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/cinefiles/cinefilesUOCbyApprovalStatus.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.6.0.final using JasperReports Library version 6.6.0  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="UOCApprovalStatus" pageWidth="612" pageHeight="792" whenNoDataType="NoDataSection" columnWidth="572" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="1da71959-7468-4c0d-8036-685691a34b6d">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="cinefilesUOCbyApprovalStatus" pageWidth="612" pageHeight="792" whenNoDataType="NoDataSection" columnWidth="572" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="1da71959-7468-4c0d-8036-685691a34b6d">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
@@ -10,6 +10,10 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
+        <parameter name="csid" class="java.lang.String"/>
+        <parameter name="andClause" class="java.lang.String">
+                <defaultValueExpression><![CDATA[$P{csid} != null ? ("huoc.name = '" + $P{csid} + "'") : "1 = 1"]]></defaultValueExpression>
+        </parameter>
 	<parameter name="StartDate" class="java.lang.String">
 		<parameterDescription><![CDATA[StartDate]]></parameterDescription>
 		<defaultValueExpression><![CDATA["0001-01-01"]]></defaultValueExpression>
@@ -46,6 +50,7 @@ from uoc_common uoc
 join hierarchy huoc on (uoc.id = huoc.id)
 where get_uoc_authby(uoc.id, $P{AuthBy}, $P{AuthStatus}) is not null
 and coalesce(uoc.daterequested::timestamp at time zone 'US/Pacific' at time zone 'UTC', '0001-01-01') between to_date($P{StartDate}, 'yyyy-mm-dd') and to_date($P{EndDate}, 'yyyy-mm-dd')
+and $P!{andClause}
 order by uoc.daterequested, uoc.referencenumber]]>
 	</queryString>
 	<field name="authby" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/cinefiles/payloads/cinefilesUOCbyApprovalStatus.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/cinefiles/payloads/cinefilesUOCbyApprovalStatus.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Use of Collections by Approval Status</name>
-    <filename>ucbgUOCbyApprovalStatus.jrxml</filename>
+    <filename>cinefilesUOCbyApprovalStatus.jrxml</filename>
     <forDocTypes>
       <forDocType>Uoc</forDocType>
     </forDocTypes>
@@ -18,4 +18,3 @@
     <notes>Lists Use of Collections requests with a value in the 'Authorized by' field, filtered by authorized by, authorization status, and/or date requested range. Displays the record number, title, requested date, completed date, authorization date, authorizer and authorization status. Available output formats: PDF, CSV, MS Word.</notes>
   </ns2:reports_common>
 </document>
-

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/cinefiles/payloads/cinefilesUOCbyApprovalStatus.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/cinefiles/payloads/cinefilesUOCbyApprovalStatus.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Use of Collections by Approval Status</name>
-    <filename>cinefilesUOCbyApprovalStatus.jrxml</filename>
+    <filename>cinefilesUOCbyApprovalStatus.jasper</filename>
     <forDocTypes>
       <forDocType>Uoc</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/cinefiles/payloads/cinefilesUOCbyRequesterObject.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/cinefiles/payloads/cinefilesUOCbyRequesterObject.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Use of Collections by Requester and/or Object</name>
-    <filename>ucbgUOCbyRequesterObject.jasper</filename>
+    <filename>cinefilesUOCbyRequesterObject.jasper</filename>
     <forDocTypes>
       <forDocType>Uoc</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/pahmaUOCbyApprovalStatus.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/pahmaUOCbyApprovalStatus.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.6.0.final using JasperReports Library version 6.6.0  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="UOCApprovalStatus" pageWidth="612" pageHeight="792" whenNoDataType="NoDataSection" columnWidth="572" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="1da71959-7468-4c0d-8036-685691a34b6d">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="pahmaUOCbyApprovalStatus" pageWidth="612" pageHeight="792" whenNoDataType="NoDataSection" columnWidth="572" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="1da71959-7468-4c0d-8036-685691a34b6d">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
@@ -10,6 +10,10 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
+        <parameter name="csid" class="java.lang.String"/>
+        <parameter name="andClause" class="java.lang.String">
+                <defaultValueExpression><![CDATA[$P{csid} != null ? ("huoc.name = '" + $P{csid} + "'") : "1 = 1"]]></defaultValueExpression>
+        </parameter>
 	<parameter name="StartDate" class="java.lang.String">
 		<parameterDescription><![CDATA[StartDate]]></parameterDescription>
 		<defaultValueExpression><![CDATA["0001-01-01"]]></defaultValueExpression>
@@ -46,6 +50,7 @@ from uoc_common uoc
 join hierarchy huoc on (uoc.id = huoc.id)
 where get_uoc_authby(uoc.id, $P{AuthBy}, $P{AuthStatus}) is not null
 and coalesce(uoc.daterequested::timestamp at time zone 'US/Pacific' at time zone 'UTC', '0001-01-01') between to_date($P{StartDate}, 'yyyy-mm-dd') and to_date($P{EndDate}, 'yyyy-mm-dd')
+and $P!{andClause}
 order by uoc.daterequested, uoc.referencenumber]]>
 	</queryString>
 	<field name="authby" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/payloads/pahmaUOCbyApprovalStatus.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/payloads/pahmaUOCbyApprovalStatus.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Use of Collections by Approval Status</name>
-    <filename>ucbgUOCbyApprovalStatus.jrxml</filename>
+    <filename>pahmaUOCbyApprovalStatus.jrxml</filename>
     <forDocTypes>
       <forDocType>Uoc</forDocType>
     </forDocTypes>
@@ -18,4 +18,3 @@
     <notes>Lists Use of Collections requests with a value in the 'Authorized by' field, filtered by authorized by, authorization status, and/or date requested range. Displays the record number, title, requested date, completed date, authorization date, authorizer and authorization status. Available output formats: PDF, CSV, MS Word.</notes>
   </ns2:reports_common>
 </document>
-

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/payloads/pahmaUOCbyApprovalStatus.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/payloads/pahmaUOCbyApprovalStatus.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Use of Collections by Approval Status</name>
-    <filename>pahmaUOCbyApprovalStatus.jrxml</filename>
+    <filename>pahmaUOCbyApprovalStatus.jasper</filename>
     <forDocTypes>
       <forDocType>Uoc</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/payloads/pahmaUOCbyRequesterObject.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/payloads/pahmaUOCbyRequesterObject.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Use of Collections by Requester and/or Object</name>
-    <filename>ucbgUOCbyRequesterObject.jasper</filename>
+    <filename>pahmaUOCbyRequesterObject.jasper</filename>
     <forDocTypes>
       <forDocType>Uoc</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucbg/payloads/ucbgUOCbyApprovalStatus.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucbg/payloads/ucbgUOCbyApprovalStatus.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Use of Collections by Approval Status</name>
-    <filename>ucbgUOCbyApprovalStatus.jrxml</filename>
+    <filename>ucbgUOCbyApprovalStatus.jasper</filename>
     <forDocTypes>
       <forDocType>Uoc</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucbg/ucbgUOCbyApprovalStatus.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucbg/ucbgUOCbyApprovalStatus.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.6.0.final using JasperReports Library version 6.6.0  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="UOCApprovalStatus" pageWidth="612" pageHeight="792" whenNoDataType="NoDataSection" columnWidth="572" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="1da71959-7468-4c0d-8036-685691a34b6d">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ucbgUOCApprovalStatus" pageWidth="612" pageHeight="792" whenNoDataType="NoDataSection" columnWidth="572" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="1da71959-7468-4c0d-8036-685691a34b6d">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
@@ -10,6 +10,10 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
+        <parameter name="csid" class="java.lang.String"/>
+        <parameter name="andClause" class="java.lang.String">
+                <defaultValueExpression><![CDATA[$P{csid} != null ? ("huoc.name = '" + $P{csid} + "'") : "1 = 1"]]></defaultValueExpression>
+        </parameter>
 	<parameter name="StartDate" class="java.lang.String">
 		<parameterDescription><![CDATA[StartDate]]></parameterDescription>
 		<defaultValueExpression><![CDATA["0001-01-01"]]></defaultValueExpression>
@@ -46,6 +50,7 @@ from uoc_common uoc
 join hierarchy huoc on (uoc.id = huoc.id)
 where get_uoc_authby(uoc.id, $P{AuthBy}, $P{AuthStatus}) is not null
 and coalesce(uoc.daterequested::timestamp at time zone 'US/Pacific' at time zone 'UTC', '0001-01-01') between to_date($P{StartDate}, 'yyyy-mm-dd') and to_date($P{EndDate}, 'yyyy-mm-dd')
+and $P!{andClause}
 order by uoc.daterequested, uoc.referencenumber]]>
 	</queryString>
 	<field name="authby" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucjeps/payloads/ucjepsUOCbyApprovalStatus.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucjeps/payloads/ucjepsUOCbyApprovalStatus.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Use of Collections by Approval Status</name>
-    <filename>ucbgUOCbyApprovalStatus.jrxml</filename>
+    <filename>ucjepsUOCbyApprovalStatus.jrxml</filename>
     <forDocTypes>
       <forDocType>Uoc</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucjeps/payloads/ucjepsUOCbyApprovalStatus.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucjeps/payloads/ucjepsUOCbyApprovalStatus.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Use of Collections by Approval Status</name>
-    <filename>ucjepsUOCbyApprovalStatus.jrxml</filename>
+    <filename>ucjepsUOCbyApprovalStatus.jasper</filename>
     <forDocTypes>
       <forDocType>Uoc</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucjeps/payloads/ucjepsUOCbyRequesterObject.xml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucjeps/payloads/ucjepsUOCbyRequesterObject.xml
@@ -2,7 +2,7 @@
 <document name="report">
   <ns2:reports_common xmlns:ns2="http://collectionspace.org/services/report">
     <name>Use of Collections by Requester and/or Object</name>
-    <filename>ucbgUOCbyRequesterObject.jasper</filename>
+    <filename>ucjepsUOCbyRequesterObject.jasper</filename>
     <forDocTypes>
       <forDocType>Uoc</forDocType>
     </forDocTypes>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucjeps/ucjepsUOCbyApprovalStatus.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucjeps/ucjepsUOCbyApprovalStatus.jrxml
@@ -10,11 +10,11 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
-	<parameter name="StartDate" class="java.lang.String">
         <parameter name="csid" class="java.lang.String"/>
         <parameter name="andClause" class="java.lang.String">
                 <defaultValueExpression><![CDATA[$P{csid} != null ? ("huoc.name = '" + $P{csid} + "'") : "1 = 1"]]></defaultValueExpression>
         </parameter>
+	<parameter name="StartDate" class="java.lang.String">
 		<parameterDescription><![CDATA[StartDate]]></parameterDescription>
 		<defaultValueExpression><![CDATA["0001-01-01"]]></defaultValueExpression>
 	</parameter>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucjeps/ucjepsUOCbyApprovalStatus.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/ucjeps/ucjepsUOCbyApprovalStatus.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.6.0.final using JasperReports Library version 6.6.0  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="UOCApprovalStatus" pageWidth="612" pageHeight="792" whenNoDataType="NoDataSection" columnWidth="572" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="1da71959-7468-4c0d-8036-685691a34b6d">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ucjepsUOCApprovalStatus" pageWidth="612" pageHeight="792" whenNoDataType="NoDataSection" columnWidth="572" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="1da71959-7468-4c0d-8036-685691a34b6d">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
@@ -11,6 +11,10 @@
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
 	<parameter name="StartDate" class="java.lang.String">
+        <parameter name="csid" class="java.lang.String"/>
+        <parameter name="andClause" class="java.lang.String">
+                <defaultValueExpression><![CDATA[$P{csid} != null ? ("huoc.name = '" + $P{csid} + "'") : "1 = 1"]]></defaultValueExpression>
+        </parameter>
 		<parameterDescription><![CDATA[StartDate]]></parameterDescription>
 		<defaultValueExpression><![CDATA["0001-01-01"]]></defaultValueExpression>
 	</parameter>
@@ -46,6 +50,7 @@ from uoc_common uoc
 join hierarchy huoc on (uoc.id = huoc.id)
 where get_uoc_authby(uoc.id, $P{AuthBy}, $P{AuthStatus}) is not null
 and coalesce(uoc.daterequested::timestamp at time zone 'US/Pacific' at time zone 'UTC', '0001-01-01') between to_date($P{StartDate}, 'yyyy-mm-dd') and to_date($P{EndDate}, 'yyyy-mm-dd')
+and $P!{andClause}
 order by uoc.daterequested, uoc.referencenumber]]>
 	</queryString>
 	<field name="authby" class="java.lang.String"/>


### PR DESCRIPTION
1. Allow UoC by Approval Status report to run in single mode
2. Rename {deployment}UOCApprovalStatus.jrxml to {deployment}UOCbyApprovalStatus.jrxml
3. Update payload files to set supportsSingleDoc = true for UoC by Approval Status reports
4. Add missing payload files for UOCbyRequeserObject reports
5. Update payload files to use .japser extension for payload filename