### PR TITLE
CSC-1942 - Support for partial content requests

### DIFF
--- a/services/blob/service/src/main/java/org/collectionspace/services/blob/BlobResource.java
+++ b/services/blob/service/src/main/java/org/collectionspace/services/blob/BlobResource.java
@@ -58,6 +58,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -146,6 +147,46 @@ public class BlobResource extends NuxeoBasedResource {
 	    		outMimeType.append(mimeType); // blobInput's mime type was set on call to "get" above by the doc handler
 	    	}
 	    	result = BlobUtil.getBlobInput(ctx).getContentStream();
+    	} catch (Exception e) {
+    		throw bigReThrow(e, ServiceMessages.CREATE_FAILED);
+    	}
+    	
+    	if (result == null) {
+    		String errMsg = String.format("Index failed. Could not get the contents for the Blob with CSID = '%s'.",
+    				csid);
+	        Response response = Response.status(
+	                Response.Status.INTERNAL_SERVER_ERROR).entity(errMsg).type("text/plain").build();
+	        throw new CSWebApplicationException(response);
+    	}
+    	
+    	return result;
+    }
+
+    private File getBlobContentFile(ServiceContext<PoxPayloadIn, PoxPayloadOut> ctx,
+    		String csid, 
+    		String derivativeTerm, 
+    		StringBuffer outMimeType) throws CSWebApplicationException {
+    	File result = null;
+    	
+    	try {
+	    	BlobInput blobInput = BlobUtil.getBlobInput(ctx);
+	    	blobInput.setDerivativeTerm(derivativeTerm);
+	    	blobInput.setContentRequested(true);
+	    	
+	    	PoxPayloadOut response = this.get(csid, ctx);
+	    	if (logger.isDebugEnabled() == true) {
+	    		logger.debug(response.toString());
+	    	}
+	    	//
+	    	// The result of a successful get should have put the results in the
+	    	// blobInput instance
+	    	//
+	    	
+	    	String mimeType = blobInput.getMimeType();
+	    	if (mimeType != null) {
+	    		outMimeType.append(mimeType); // blobInput's mime type was set on call to "get" above by the doc handler
+	    	}
+	    	result = BlobUtil.getBlobInput(ctx).getBlobFile();
     	} catch (Exception e) {
     		throw bigReThrow(e, ServiceMessages.CREATE_FAILED);
     	}
@@ -287,9 +328,10 @@ public class BlobResource extends NuxeoBasedResource {
 	    	ctx = createServiceContext(jaxRsRequest, uriInfo);
 			BlobsCommon blobsCommon = getBlobsCommon(csid);
 	    	StringBuffer mimeType = new StringBuffer();
-	    	InputStream contentStream = getBlobContent(ctx, csid, null /*derivative term*/, mimeType /*will get set*/);
+//	    	InputStream contentStream = getBlobContent(ctx, csid, null /*derivative term*/, mimeType /*will get set*/);
+	    	File contentFile = getBlobContentFile(ctx, csid, null /*derivative term*/, mimeType /*will get set*/);
 		    
-	    	Response.ResponseBuilder responseBuilder = Response.ok(contentStream, mimeType.toString());
+	    	Response.ResponseBuilder responseBuilder = Response.ok(contentFile, mimeType.toString());
 	    	setCacheControl(ctx, responseBuilder);
 	    	responseBuilder = responseBuilder.header("Content-Disposition","inline;filename=\""
 	    			+ blobsCommon.getName() +"\"");
@@ -300,7 +342,7 @@ public class BlobResource extends NuxeoBasedResource {
 
     	return result;
     }
-    
+
 	private BlobsCommon getBlobsCommon(String csid) throws Exception {
     	BlobsCommon result = null;
     	

--- a/services/blob/service/src/main/java/org/collectionspace/services/blob/nuxeo/BlobDocumentModelHandler.java
+++ b/services/blob/service/src/main/java/org/collectionspace/services/blob/nuxeo/BlobDocumentModelHandler.java
@@ -166,6 +166,7 @@ extends NuxeoDocumentModelHandler<BlobsCommon> {
 			if (getContentFlag == true) {
 				if (blobOutput != null) {
 					blobInput.setContentStream(blobOutput.getBlobInputStream());
+					blobInput.setBlobFile(blobOutput.getBlobFile());
 				} else {
 					blobInput.setContentStream(null);
 				}

--- a/services/common/src/main/java/org/collectionspace/services/common/blob/BlobOutput.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/blob/BlobOutput.java
@@ -1,5 +1,6 @@
 package org.collectionspace.services.common.blob;
 
+import java.io.File;
 import java.io.InputStream;
 import org.collectionspace.services.blob.BlobsCommon;
 
@@ -7,6 +8,7 @@ public class BlobOutput {
 	private String mimeType;
 	private BlobsCommon blobsCommon;
 	private InputStream blobInputStream;
+	private File blobFile;
 
 	public BlobsCommon getBlobsCommon() {
 		return blobsCommon;
@@ -25,5 +27,11 @@ public class BlobOutput {
 	}
 	public void setMimeType(String mimeType) {
 		this.mimeType = mimeType;
+	}
+	public void setBlobFile(File file) {
+		this.blobFile = file;
+	}
+	public File getBlobFile() {
+		return this.blobFile;
 	}
 }

--- a/services/common/src/main/java/org/collectionspace/services/common/imaging/nuxeo/NuxeoBlobUtils.java
+++ b/services/common/src/main/java/org/collectionspace/services/common/imaging/nuxeo/NuxeoBlobUtils.java
@@ -1170,6 +1170,7 @@ public class NuxeoBlobUtils {
 //							remoteStream); 	
 //					result.setBlobInputStream(bufferedInputStream);
 					result.setBlobInputStream(remoteStream);
+					result.setBlobFile(docBlob.getFile());
 				}
 			} catch (DocumentNotFoundException d) {
 				throw d;


### PR DESCRIPTION
In order to support partial content requests for media like video and audio, I've Updated the Blob service to build responses with File objects rather than InputStream objects