### PR TITLE
CSC-1972ucb: Add missing function required for findhybaffnoauthname

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/ucbg/ucbg-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/ucbg/ucbg-tenant-bindings.delta.xml
@@ -68,6 +68,10 @@
                     </service:property>
                     <service:property merge:matcher="skip" merge:action="insert">
                         <service:key>sqlScriptName</service:key>
+                        <service:value>fnc-public-findnoauthname-nuxeo_botgarden.sql</service:value>
+                    </service:property>
+                    <service:property merge:matcher="skip" merge:action="insert">
+                        <service:key>sqlScriptName</service:key>
                         <service:value>fnc-public-findhybaffnoauthname-nuxeo_botgarden.sql</service:value>
                     </service:property>
                 </service:params>

--- a/services/common/src/main/resources/db/postgresql/tenants/ucbg/fnc-public-findnoauthname-nuxeo_botgarden.sql
+++ b/services/common/src/main/resources/db/postgresql/tenants/ucbg/fnc-public-findnoauthname-nuxeo_botgarden.sql
@@ -1,0 +1,54 @@
+-- function to get taxon name with no author; requires taxon name as refname, taxon_common.id or taxon displayname
+
+-- DROP FUNCTION public.findnoauthname(taxonname varchar);
+
+CREATE OR REPLACE FUNCTION public.findnoauthname(taxonname varchar)
+ RETURNS varchar
+ LANGUAGE plpgsql
+ IMMUTABLE STRICT
+AS $$
+
+DECLARE noauthname varchar(300);
+
+BEGIN
+  if ($1 = '') then
+    return null;
+
+  elsif ($1 ~ '^urn:') then
+    select ttg.termdisplayname into noauthname
+    from taxon_common tc
+    join hierarchy httg on (
+      tc.id = httg.parentid
+      and httg.primarytype = 'taxonTermGroup')
+    join taxontermgroup ttg on (
+      httg.id = ttg.id
+      and ttg.termtype = 'Taxon No Author Name')
+    where tc.refname = $1;
+
+  elsif ($1 ~ '^[a-z0-9-]+[0-9]') then
+    select ttg.termdisplayname into noauthname
+    from taxon_common tc
+    join hierarchy httg on (
+      tc.id = httg.parentid
+      and httg.primarytype = 'taxonTermGroup')
+    join taxontermgroup ttg on (
+      httg.id = ttg.id
+      and ttg.termtype = 'Taxon No Author Name')
+    where tc.id = $1;
+
+  else
+    select ttg.termdisplayname into noauthname
+    from taxon_common tc
+    join hierarchy httg on (
+      tc.id = httg.parentid
+      and httg.primarytype = 'taxonTermGroup')
+    join taxontermgroup ttg on (
+      httg.id = ttg.id
+      and ttg.termtype = 'Taxon No Author Name')
+    where getdispl(tc.refname) = $1;
+  end if;
+
+  return noauthname;
+END;
+$$;
+


### PR DESCRIPTION
Upon writing Post-Deploy and QA instructions, I discovered I did not check in the code for the findnoauthname function which is a new function required by the findhybaffnoauthname function, used by the UCBG Rare Status reports (CSC-1954, CSC-1955).