### PR TITLE
NOJIRA: Bump UCBG Plugin Profile version to 2.0.4

### DIFF
--- a/cspace-ui/ucbg/build.properties
+++ b/cspace-ui/ucbg/build.properties
@@ -3,4 +3,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-ucbg
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileUCBG
-tenant.ui.profile.plugin.version=2.0.4-rc.3
+tenant.ui.profile.plugin.version=2.0.4


### PR DESCRIPTION
republished cspace-ui-plugin-profile-ucbg and cspace-ui-plugin-ext-ucbnh-taxon to remove -rc suffixes.
cspace-ui-plugin-profile-ucbg version 2.0.4
cspace-ui-plugin-ext-ucbnh-taxon 1.0.2