### PR TITLE
UCB 8.0 Updates

### DIFF
--- a/cspace-ui/pahma/build.properties
+++ b/cspace-ui/pahma/build.properties
@@ -3,4 +3,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-pahma
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfilePAHMA
-tenant.ui.profile.plugin.version=4.0.0-rc.3
+tenant.ui.profile.plugin.version=4.0.0-rc.4


### PR DESCRIPTION
This updates UCB 8.0 services to resolve issues found in QA:

- The script that migrates numberofobjects data to objectcountgroup now sets objectcounttype to piece count (for PAHMA only)
- The PAHMA UI plugin is upgraded to version 4.0.0-rc.4