### PR TITLE
8.0 updates to support BAMPFA

### DIFF
--- a/cspace-ui/bampfa/build.properties
+++ b/cspace-ui/bampfa/build.properties
@@ -3,4 +3,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-bampfa
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileBAMPFA
-tenant.ui.profile.plugin.version=2.0.5
+tenant.ui.profile.plugin.version=3.0.0-rc.1

--- a/src/main/resources/db/postgresql/upgrade/8.0.0/post-init/02_collectionobject_numberofobjects.sql
+++ b/src/main/resources/db/postgresql/upgrade/8.0.0/post-init/02_collectionobject_numberofobjects.sql
@@ -13,7 +13,7 @@ BEGIN
     IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='collectionobjects_common' AND column_name='numberofobjects') THEN
         IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='collectionobjects_pahma' AND column_name='inventorycount') THEN
             -- If this isn't PAHMA, create a temp (empty) collectionobjects_pahma table so that the rest of this script will work.
-            CREATE TEMP TABLE collectionobjects_pahma (inventorycount VARCHAR);
+            CREATE TEMP TABLE collectionobjects_pahma (id VARCHAR, inventorycount VARCHAR);
         END IF;
 
         IF starts_with(current_database(), 'pahma') THEN


### PR DESCRIPTION
This contains a couple of small updates to support upgrading BAMPFA to 8.0.

- Upgrade the BAMPFA UI plugin.
- Fix an error in the collectionobject numberofobjects upgrade script when running in non-PAHMA tenants.
