### PR TITLE
CSC-2359ucb: update get_deplname for new servername format; add get_deplname to post-init scripts

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -83,6 +83,10 @@
 						<service:key>sqlScriptName</service:key>
 						<service:value>fnc-public-getdispl.sql</service:value>
 					</service:property>
+					<service:property>
+						<service:key>sqlScriptName</service:key>
+						<service:value>fnc-public-get_deplname.sql</service:value>
+					</service:property>
 				</service:params>
 			</service:initHandler>
 		</tenant:serviceBindings>

--- a/services/common/src/main/resources/db/postgresql/fnc-public-get_deplname.sql
+++ b/services/common/src/main/resources/db/postgresql/fnc-public-get_deplname.sql
@@ -1,3 +1,8 @@
+/* Used by UCB deployments to determine qa|prod server.
+-- old servername format: cs-ucb-(qa|prod)-db.lyrtech.org
+-- new servername format: cspace-ucb-(qa|production)
+*/
+
 CREATE OR REPLACE FUNCTION public.get_deplname()
  RETURNS character varying
  LANGUAGE plpgsql
@@ -10,7 +15,7 @@ BEGIN
 
 SELECT 
   REGEXP_REPLACE(REGEXP_REPLACE(current_database(), '[_].*$', ''), 'botgarden', 'ucbg') || 
-  CASE WHEN REGEXP_REPLACE(name, '^.*-(qa|prod)-.*$', '\1') = 'qa' THEN '.qa' ELSE '' END
+  CASE WHEN REGEXP_REPLACE(name, '^.*-(qa)-?.*$', '\1') = 'qa' THEN '.qa' ELSE '' END
 INTO namestr
 FROM utils.servername;
 


### PR DESCRIPTION
CSC-2147 changes to add fnc-public-get_deplname.sql to post-init scripts didn't get merged from ucb_6.0 to ucb_8.0.