### PR TITLE
UCJEPS updates for 8.0

### DIFF
--- a/cspace-ui/ucjeps/build.properties
+++ b/cspace-ui/ucjeps/build.properties
@@ -3,4 +3,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-ucjeps
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileUCJEPS
-tenant.ui.profile.plugin.version=2.0.2
+tenant.ui.profile.plugin.version=3.0.0-rc.1


### PR DESCRIPTION
This just updates the version of the UCJEPS UI plugin to the one used in 8.0.