### PR TITLE
CSC-2351main: update PAHMA report queries for objectCount/objectCountNote schema changes

### DIFF
--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/AccessionSummary,Wide,Culture.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/AccessionSummary,Wide,Culture.jrxml
@@ -7,41 +7,44 @@
 		<defaultValueExpression><![CDATA["0cca1640-6014-4b3e-8453"]]></defaultValueExpression>
 	</parameter>
 	<queryString>
-		<![CDATA[SELECT  ac.acquisitionreferencenumber accessionNumber,
-        aa.acquisitionDescription,
-        h1.name AS "csid",
-        co.objectnumber AS "Museum No.",
-        cp.sortableobjectnumber AS "sort",
-        ong.objectName AS "Name",
-        bd.item AS "Description",
-        CASE WHEN (fcp.item IS NOT NULL AND fcp.item <> '')
-          THEN regexp_replace(fcp.item, '^.*\)''(.*)''$', '\1') END AS "Site",
-        co.numberofobjects objectCount,
-        case when (apg.assocpeople is not null and apg.assocpeople <> '') then
-          regexp_replace(apg.assocpeople, '^.*\)''(.*)''$', '\1')
-        end as culturalgroup
+		<![CDATA[SELECT
+	ac.acquisitionreferencenumber AS accessionnumber,
+	aa.acquisitionDescription,
+	hac.name AS csid,
+	cc.objectnumber AS "Museum No.",
+	cp.sortableobjectnumber AS "sort",
+	ong.objectName AS "Name",
+	bd.item AS "Description",
+	GETDISPL(fcp.item) AS "Site",
+	ocg.objectCount AS objectcount,
+	GETDISPL(apg.assocpeople) AS culturalgroup
 FROM acquisitions_common ac
-JOIN hierarchy h1 ON (ac.id=h1.id)
-JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)
-JOIN hierarchy h2 ON (rc1.objectcsid=h2.name)
-JOIN collectionobjects_common co ON (h2.id=co.id)
-LEFT OUTER JOIN collectionobjects_pahma cp ON (co.id=cp.id)
-LEFT OUTER JOIN collectionobjects_anthropology ca on (co.id=ca.id)
-LEFT OUTER JOIN acquisitions_anthropology aa on (ac.id=aa.id)
-
-LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
-
-left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:assocPeopleGroupList')
-left outer join assocpeoplegroup apg on (apg.id=h4.id)
-
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
-
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (co.id=fcp.id AND fcp.pos=0)
-
-JOIN misc ms ON (co.id=ms.id AND ms.lifecyclestate <> 'deleted')
-WHERE rc1.subjectcsid =$P{csid}
-
+JOIN hierarchy hac ON (ac.id = hac.id)
+JOIN relations_common rc ON (hac.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+JOIN hierarchy hcc ON (rc.objectcsid = hcc.name)
+JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN acquisitions_anthropology aa ON (ac.id = aa.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hapg ON (cc.id = hapg.parentid
+	AND hapg.primarytype = 'assocPeopleGroup')
+	AND hapg.pos = 0
+LEFT OUTER JOIN assocpeoplegroup apg ON (apg.id = hapg.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (cc.id = bd.id
+	AND bd.pos = 0)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id
+	AND fcp.pos = 0)
+JOIN misc m ON (cc.id = m.id
+	AND m.lifecyclestate <> 'deleted')
+WHERE hac.name = $P{csid}
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="accessionnumber" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/AccessionSummary-groupResearcher.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/AccessionSummary-groupResearcher.jrxml
@@ -7,40 +7,44 @@
 		<defaultValueExpression><![CDATA["0cca1640-6014-4b3e-8453"]]></defaultValueExpression>
 	</parameter>
 	<queryString>
-		<![CDATA[SELECT  ac.acquisitionreferencenumber accessionNumber,
-        aa.acquisitionDescription,
-        h1.name AS "csid",
-        co.objectnumber AS "Museum No.",
-        cp.sortableobjectnumber AS "sort",
-        ong.objectName AS "Name",
-        bd.item AS "Description",
-        CASE WHEN (fcp.item IS NOT NULL AND fcp.item <> '')
-          THEN regexp_replace(fcp.item, '^.*\)''(.*)''$', '\1') END AS "Site",
-        co.numberofobjects objectCount,
-        case when (apg.assocpeople is not null and apg.assocpeople <> '') then
-          regexp_replace(apg.assocpeople, '^.*\)''(.*)''$', '\1')
-        end as culturalgroup
+		<![CDATA[SELECT
+	ac.acquisitionreferencenumber AS accessionnumber,
+	aa.acquisitionDescription AS acquisitiondescription,
+	hac.name AS csid,
+	cc.objectnumber AS "Museum No.",
+	cp.sortableobjectnumber AS "sort",
+	ong.objectName AS "Name",
+	bd.item AS "Description",
+	GETDISPL(fcp.item) AS "Site",
+	ocg.objectCount AS objectcount,
+	GETDISPL(apg.assocpeople) AS culturalgroup
 FROM acquisitions_common ac
-JOIN hierarchy h1 ON (ac.id=h1.id)
-JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)
-JOIN hierarchy h2 ON (rc1.objectcsid=h2.name)
-JOIN collectionobjects_common co ON (h2.id=co.id)
-JOIN collectionobjects_pahma cp ON (co.id=cp.id)
-join collectionobjects_anthropology ca on (co.id=ca.id)
-JOIN acquisitions_anthropology aa on (ac.id=aa.id)
-
-LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
-
-left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:assocPeopleGroupList')
-left outer join assocpeoplegroup apg on (apg.id=h4.id)
-
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
-
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (co.id=fcp.id AND fcp.pos=0)
-
-WHERE rc1.subjectcsid =$P{csid}
-
+JOIN hierarchy hac ON (ac.id = hac.id)
+JOIN relations_common rc ON (hac.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+JOIN hierarchy hcc ON (rc.objectcsid = hcc.name)
+JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+JOIN acquisitions_anthropology aa ON (ac.id = aa.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hapg ON (cc.id = hapg.parentid
+	AND hapg.primarytype = 'assocPeopleGroup'
+	AND hapg.pos = 0)
+LEFT OUTER JOIN assocpeoplegroup apg ON (hapg.id = apg.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup')
+	AND hocg.pos = 0
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = cc.id
+	AND bd.pos = 0)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id
+	AND fcp.pos = 0)
+JOIN misc m ON (cc.id = m.id
+        AND m.lifecyclestate <> 'deleted')
+WHERE hac.name = $P{csid}
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="accessionnumber" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ArcheologicalSiteReport.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ArcheologicalSiteReport.jrxml
@@ -15,60 +15,51 @@
 		<defaultValueExpression><![CDATA["b6d49fa9-788a-477a-993e"]]></defaultValueExpression>
 	</parameter>
 	<queryString language="SQL">
-		<![CDATA[select
-findcurrentlocation(co1.id) currLocation,
-co1.numberofobjects objectCount,
-ptg.termname as site,
-substring(pcoc.item, position(')''' in pcoc.item)+2, length(pcoc.item)-position(')''' in pcoc.item)-2) as fieldcollectionplace,
-g.title groupTitle,
-(case when g.scopenote is Null then '' else g.scopenote end) scopeNote,
-co1.id objectid,
-co1.objectnumber objectNumber,
-cop.sortableobjectnumber,
-(case when ong.objectName is NULL then '' else ong.objectName end) objectName,
-sd.datedisplaydate fieldCollectionDate,
-(case when bd.item is NULL then '' else bd.item end) description,
-r.subjectcsid relationsubjectid,
-r.objectcsid,
-h4.id h4id,
-h4.parentid h4pid,
-h3.id h3id,
-h3.parentid h3pid,
-misc.lifecyclestate lifecyclestate
-from groups_common g
-left outer join hierarchy h1 on (g.id = h1.id)
-inner join relations_common r on (h1.name = r.objectcsid)
-left outer join hierarchy h2 on (r.subjectcsid = h2.name)
-left outer join collectionobjects_common co1 on (h2.id = co1.id)
-left outer join collectionobjects_pahma cop on (h2.id = cop.id)
-left outer join collectionobjects_common_briefdescriptions bd on (co1.id = bd.id AND bd.pos = 0)
-inner join misc on misc.id = co1.id
-inner join hierarchy h3 on (h3.name = r.subjectcsid)
-inner join hierarchy h4 on (h3.id = h4.parentid)
-inner join structureddategroup sd on (h4.id = sd.id)
-inner join collectionspace_core core on core.id=co1.id
-left outer join hierarchy h5 on (co1.id = h5.parentid)
-inner join objectnamegroup ong on (ong.id=h5.id)
-
-left outer join collectionobjects_pahma_pahmafieldcollectionplacelist pcoc on co1.id = pcoc.id
-left outer join places_common pc on pc.refname = pcoc.item
-left outer join hierarchy h6 on pc.id = h6.parentid
-join placetermgroup ptg on ptg.id = h6.id
-
-where misc.lifecyclestate <> 'deleted'
-and h4.name = 'collectionobjects_pahma:pahmaFieldCollectionDateGroupList'
-and core.tenantid=$P{tenantid}
-and h1.name= $P{csid}
-order by ptg.termname,cop.sortableobjectnumber]]>
+		<![CDATA[SELECT
+	GETDISPL(cc.computedcurrentlocation) AS currLocation,
+	ocg.objectCount AS objectCount,
+	ptg.termname AS site,
+	GETDISPL(fcp.item) AS fieldcollectionplace,
+	COALESCE(gc.scopenote, '') AS scopeNote,
+	cc.objectnumber AS objectNumber,
+	cp.sortableobjectnumber,
+	COALESCE(ong.objectName, '') AS objectName,
+	COALESCE(bd.item, '') AS description
+FROM groups_common gc
+LEFT OUTER JOIN hierarchy hgc ON (gc.id = hgc.id)
+JOIN relations_common rc ON (hgc.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+LEFT OUTER JOIN hierarchy hcc ON (hcc.name = rc.objectcsid)
+LEFT OUTER JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (cc.id = bd.id
+	AND bd.pos = 0)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id)
+LEFT OUTER JOIN places_common pc ON (fcp.item = pc.refname)
+LEFT OUTER JOIN hierarchy hpc ON (pc.id = hpc.parentid
+	AND hpc.primarytype = 'placeTermGroup')
+LEFT OUTER JOIN placetermgroup ptg ON (hpc.id = ptg.id)
+JOIN misc m ON (cc.id = m.id
+	AND m.lifecyclestate <> 'deleted')
+WHERE hgc.name = $P{csid}
+ORDER BY ptg.termname, cp.sortableobjectnumber]]>
 	</queryString>
-	<field name="objectNumber" class="java.lang.String"/>
-	<field name="objectName" class="java.lang.String"/>
 	<field name="currLocation" class="java.lang.String"/>
 	<field name="objectCount" class="java.lang.Integer"/>
-	<field name="fieldcollectionplace" class="java.lang.String"/>
 	<field name="site" class="java.lang.String"/>
-	<field name="description" class="java.lang.String"/>
+	<field name="fieldcollectionplace" class="java.lang.String"/>
 	<field name="scopeNote" class="java.lang.String"/>
+	<field name="objectNumber" class="java.lang.String"/>
+	<field name="objectName" class="java.lang.String"/>
+	<field name="description" class="java.lang.String"/>
 	<group name="currLocation">
 		<groupExpression><![CDATA[$F{currLocation}]]></groupExpression>
 		<groupHeader>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ComponentCheck.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ComponentCheck.jrxml
@@ -20,28 +20,33 @@
 	</parameter>
 	<queryString>
 		<![CDATA[SELECT
-  hco.name AS csid,
-  CASE WHEN ca.computedcrate IS NULL THEN GETDISPL(co.computedcurrentlocation)
-    ELSE GETDISPL(co.computedcurrentlocation) || ': ' || GETDISPL(ca.computedcrate)
-  END AS storageLocation,
-  CASE WHEN ca.computedcrate IS NULL THEN REPLACE(GETDISPL(co.computedcurrentlocation), ' ', '0')
-    ELSE REPLACE(GETDISPL(co.computedcurrentlocation), ' ', '0') || '0' || REPLACE(GETDISPL(ca.computedcrate), ' ', '0')
-  END AS locationKey,
-  GETDISPL(ca.computedcrate) AS computedCrate,
-  co.objectnumber AS objectNumber,
-  cp.sortableobjectnumber AS sortableObjectNumber,
-  co.numberofobjects AS objectCount,
-  ong.objectName AS objectName,
-  cp.inventorycount AS countNote
-FROM collectionobjects_common co
-JOIN hierarchy hco ON (co.id = hco.id)
-LEFT OUTER JOIN hierarchy hong ON (co.id = hong.parentid AND hong.pos = 0 AND hong.name = 'collectionobjects_common:objectNameList')
+	hcc.name AS csid,
+        COALESCE(GETDISPL(cc.computedcurrentlocation) || ': ' || GETDISPL(ca.computedcrate),
+                GETDISPL(cc.computedcurrentlocation)) AS storageLocation,
+        COALESCE(REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0') || '0' || REPLACE(GETDISPL(ca.computedcrate), ' ', '0'),
+                REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0')) AS locationKey,
+	GETDISPL(ca.computedcrate) AS computedCrate,
+	cc.objectnumber AS objectNumber,
+	cp.sortableobjectnumber AS sortableObjectNumber,
+	ocg.objectCount AS objectCount,
+	ong.objectName AS objectName,
+	ocg.objectCountNote AS countNote
+FROM collectionobjects_common cc
+JOIN hierarchy hcc ON (cc.id = hcc.id)
+LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN collectionobjects_anthropology ca ON (cc.id = ca.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
 LEFT OUTER JOIN objectnamegroup ong ON (ong.id = hong.id)
-LEFT OUTER JOIN collectionobjects_pahma cp ON (co.id = cp.id)
-LEFT OUTER JOIN collectionobjects_anthropology ca ON (co.id = ca.id)
-JOIN misc ms ON (co.id = ms.id AND ms.lifecyclestate <> 'deleted')
-WHERE REPLACE(GETDISPL(co.computedcurrentlocation), ' ', '0') >= REPLACE($P{startLocDispl}, ' ', '0')
-  AND REPLACE(GETDISPL(co.computedcurrentlocation), ' ', '0') <= REPLACE($P{endLocDispl}, ' ', '0')
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+JOIN misc m ON (cc.id = m.id
+	AND m.lifecyclestate <> 'deleted')
+WHERE REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0') >= REPLACE($P{startLocDispl}, ' ', '0')
+AND REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0') <= REPLACE($P{endLocDispl}, ' ', '0')
 ORDER BY locationKey, sortableObjectNumber, objectName DESC]]>
 	</queryString>
 	<field name="csid" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/GroupWithImages.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/GroupWithImages.jrxml
@@ -6,43 +6,65 @@
 	<parameter name="groupcsid" class="java.lang.String"/>
 	<queryString>
 		<![CDATA[SELECT
-  gc.title AS groupTitle,
-  coc.objectnumber AS museumNum,
-  coc.numberofobjects AS objCount,
-  cp.sortableobjectnumber AS sortableObjNum,
-  ong.objectName AS objName,
-  bd.item AS objDesc,
-  STRING_AGG(DISTINCT GETDISPL(apg.assocpeople), '; ') AS culture,
-  GETDISPL(fcp.item) AS fieldCollPlace,
-  (SELECT 'https://webapps' || case when get_deplname() ~ 'qa' then '-qa' else '' end || '.cspace.berkeley.edu/pahma/imageserver/blobs/' || mc.blobcsid || '/derivatives/Medium/content' 
-    FROM relations_common rcmc
-    LEFT OUTER JOIN hierarchy hmc ON (hmc.name = rcmc.subjectcsid)
-    LEFT OUTER JOIN media_common mc ON (hmc.id = mc.id)
-    LEFT OUTER JOIN media_pahma mp ON (mc.id = mp.id)
-    LEFT OUTER JOIN misc mmc ON (mmc.id = mc.id)
-    LEFT OUTER JOIN collectionspace_core csc ON (mc.id = csc.id)
-    WHERE hcoc.name = rcmc.objectcsid
-    AND rcmc.subjectdocumenttype = 'Media'
-    AND mmc.lifecyclestate <> 'deleted'
-    ORDER BY coalesce(mp.primarydisplay::integer, 0) DESC, csc.updatedat DESC LIMIT 1) AS imageFilepath
-FROM collectionobjects_common coc
-LEFT OUTER JOIN collectionobjects_pahma cp ON (coc.id = cp.id)
-LEFT OUTER JOIN collectionobjects_anthropology ca ON (coc.id = ca.id)
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (coc.id = bd.id AND bd.pos = 0)
-JOIN hierarchy hcoc ON (coc.id = hcoc.id)
-JOIN misc mcoc on (coc.id = mcoc.id)
-JOIN relations_common rc ON (hcoc.name = rc.objectcsid AND rc.subjectdocumenttype = 'Group')
-JOIN hierarchy hgc ON (rc.subjectcsid = hgc.name)
-LEFT OUTER JOIN groups_common gc ON (hgc.id = gc.id)
-LEFT OUTER JOIN hierarchy hong ON (coc.id = hong.parentid AND hong.primarytype = 'objectNameGroup' AND (hong.pos = 0 OR hong.pos IS NULL))
+	gc.title AS groupTitle,
+	cc.objectnumber AS museumNum,
+	ocg.objectCount AS objCount,
+	cp.sortableobjectnumber AS sortableObjNum,
+	ong.objectName AS objName,
+	bd.item AS objDesc,
+	STRING_AGG(DISTINCT GETDISPL(apg.assocpeople), '; ') AS culture,
+	GETDISPL(fcp.item) AS fieldCollPlace,
+	(	SELECT 
+			'https://webapps' 
+			|| CASE WHEN get_deplname() ~ 'qa' THEN '-qa' ELSE '' END 
+			|| '.cspace.berkeley.edu/pahma/imageserver/blobs/' 
+			|| mc.blobcsid 
+			|| '/derivatives/Medium/content' 
+		FROM relations_common rcmc
+		LEFT OUTER JOIN hierarchy hmc ON (rcmc.subjectcsid = hmc.name
+			AND rcmc.subjectdocumenttype = 'Media'
+			AND rcmc.objectdocumenttype = 'CollectionObject')
+		LEFT OUTER JOIN media_common mc ON (hmc.id = mc.id)
+		LEFT OUTER JOIN media_pahma mp ON (mc.id = mp.id)
+		LEFT OUTER JOIN misc mmc ON (mc.id = mmc.id
+			AND mmc.lifecyclestate <> 'deleted')
+		LEFT OUTER JOIN collectionspace_core csc ON (mc.id = csc.id)
+		WHERE rcmc.objectcsid = hcc.name
+		ORDER BY COALESCE(mp.primarydisplay::integer, 0) DESC, csc.updatedat DESC LIMIT 1) AS imageFilepath
+FROM groups_common gc
+JOIN hierarchy hgc ON (gc.id = hgc.id)
+LEFT OUTER JOIN relations_common rc ON (hgc.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+LEFT OUTER JOIN hierarchy hcc on (rc.objectcsid = hcc.name)
+LEFT OUTER JOIN collectionobjects_common cc on (hcc.id = cc.id)
+LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND (hong.pos = 0 OR hong.pos IS NULL))
 LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
-LEFT OUTER JOIN hierarchy hapg ON (coc.id = hapg.parentid AND hapg.primarytype = 'assocPeopleGroup')
+LEFT OUTER JOIN hierarchy hapg ON (cc.id = hapg.parentid
+	AND hapg.primarytype = 'assocPeopleGroup')
 LEFT OUTER JOIN assocpeoplegroup apg ON (hapg.id = apg.id)
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (coc.id = fcp.id AND (fcp.pos = 0 OR fcp.pos IS NULL))
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (cc.id = bd.id
+	AND bd.pos = 0)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id
+	AND (fcp.pos = 0 OR fcp.pos IS NULL))
+JOIN misc m ON (cc.id = m.id
+	AND m.lifecyclestate <> 'deleted')
 WHERE hgc.name = $P{groupcsid}
-AND mcoc.lifecyclestate <> 'deleted'
-GROUP BY gc.title, coc.objectnumber, coc.numberofobjects, ong.objectname, bd.item,
-  fcp.item, cp.sortableobjectnumber, hcoc.name
+GROUP BY
+	gc.title,
+	cc.objectnumber,
+	ocg.objectCount,
+	ong.objectname,
+	bd.item,
+	fcp.item,
+	cp.sortableobjectnumber,
+	hcc.name
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="groupTitle" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/HsrPhaseOneInventory.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/HsrPhaseOneInventory.jrxml
@@ -22,33 +22,38 @@
 	</parameter>
 	<queryString>
 		<![CDATA[SELECT
-  CASE WHEN ca.computedcrate IS NULL
-    THEN getdispl(cc.computedcurrentlocation)
-    ELSE getdispl(cc.computedcurrentlocation) || ': ' || getdispl(ca.computedcrate)
-  END AS storageLocation,
-  CASE WHEN ca.computedcrate IS NULL
-    THEN REPLACE(getdispl(cc.computedcurrentlocation), ' ', '0')
-    ELSE REPLACE(getdispl(cc.computedcurrentlocation), ' ', '0') || '0' || REPLACE(getdispl(ca.computedcrate), ' ', '0')
-  END AS locationKey,
-  GETDISPL(ca.computedcrate) AS computedCrate,
-  cc.objectnumber AS objectNumber,
-  cp.sortableobjectnumber AS sortableObjectNumber,
-  cc.numberofobjects AS objectCount,
-  GETDISPL(fcp.item) AS fieldCollectionPlace,
-  ong.objectName AS objectName,
-  bd.item AS briefDescription,
-  cp.inventorycount AS countNote
+        COALESCE(GETDISPL(cc.computedcurrentlocation) || ': ' || GETDISPL(ca.computedcrate),
+                GETDISPL(cc.computedcurrentlocation)) AS storageLocation,
+        COALESCE(REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0') || '0' || REPLACE(GETDISPL(ca.computedcrate), ' ', '0'),
+                REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0')) AS locationKey,
+	GETDISPL(ca.computedcrate) AS computedCrate,
+	cc.objectnumber AS objectNumber,
+	cp.sortableobjectnumber AS sortableObjectNumber,
+	ocg.objectCount AS objectCount,
+	GETDISPL(fcp.item) AS fieldCollectionPlace,
+	ong.objectName AS objectName,
+	bd.item AS briefDescription,
+	ocg.objectCountNote AS countNote
 FROM collectionobjects_common cc
-LEFT OUTER JOIN hierarchy h1 ON (cc.id = h1.parentid AND h1.pos = 0 AND h1.name = 'collectionobjects_common:objectNameList')
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id = h1.id)
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (fcp.id = cc.id AND (fcp.pos = 0 OR fcp.pos IS NULL))
-LEFT OUTER JOIN places_common pc ON (pc.shortidentifier = REGEXP_REPLACE(fcp.item, '^.*item:name\((.*)\)''.*', '\1'))
 LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
 LEFT OUTER JOIN collectionobjects_anthropology ca ON (cc.id = ca.id)
-JOIN misc ms ON (cc.id = ms.id and ms.lifecyclestate <> 'deleted')
-FULL OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = cc.id AND bd.pos = 0)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (ong.id = hong.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (fcp.id = cc.id
+	AND (fcp.pos = 0 OR fcp.pos IS NULL))
+LEFT OUTER JOIN places_common pc ON (pc.shortidentifier = REGEXP_REPLACE(fcp.item, '^.*item:name\((.*)\)''.*', '\1'))
+FULL OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = cc.id
+	AND bd.pos = 0)
+JOIN misc ms ON (cc.id = ms.id
+	AND ms.lifecyclestate <> 'deleted')
 WHERE REPLACE(getdispl(cc.computedcurrentlocation), ' ', '0') >= REPLACE($P{startLocDispl}, ' ', '0')
-  AND REPLACE(getdispl(cc.computedcurrentlocation), ' ', '0') <= REPLACE($P{endLocDispl}, ' ', '0')
+AND REPLACE(getdispl(cc.computedcurrentlocation), ' ', '0') <= REPLACE($P{endLocDispl}, ' ', '0')
 ORDER BY locationKey, sortableObjectNumber, objectName DESC]]>
 	</queryString>
 	<field name="storageLocation" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/KeyInformationReview.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/KeyInformationReview.jrxml
@@ -15,64 +15,44 @@
 		<defaultValueExpression><![CDATA["35aee97c-c238-45f6-a077"]]></defaultValueExpression>
 	</parameter>
 	<queryString language="SQL">
-		<![CDATA[select
-g.title groupTitle,
-(case when g.scopenote is Null then '' else g.scopenote end) scopeNote,
-co1.id objectid,
-co1.objectnumber objectNumber,
-co1.objectnumber componentNumber,
-co1.numberofobjects objectCount,
-findcurrentlocation(co1.id) location1,
-findcurrentlocation(co1.id) location2,
-findcurrentlocation(co1.id) currLocation,
-'geography' Geography,
-'culture' Culture,
-'filecode' FileCode,
-(case when ong.objectName is NULL then '' else ong.objectName end) objectName,
-(case when ong.objectName is NULL then '' else ong.objectName end) componentName,
-sd.datedisplaydate fieldCollectionDate,
-(case when bd.item is NULL then '' else bd.item end) description,
-r.subjectcsid relationsubjectid,
-r.objectcsid,
-h4.id h4id,
-h4.parentid h4pid,
-h3.id h3id,
-h3.parentid h3pid,
-misc.lifecyclestate lifecyclestate
-from groups_common g
-left outer join hierarchy h1 on (g.id = h1.id)
-inner join relations_common r on (h1.name = r.objectcsid)
-left outer join hierarchy h2 on (r.subjectcsid = h2.name)
-left outer join collectionobjects_common co1 on (h2.id = co1.id)
-left outer join collectionobjects_common_briefdescriptions bd on (co1.id = bd.id AND bd.pos = 0)
-inner join misc on misc.id = co1.id
-inner join hierarchy h3 on (h3.name = r.subjectcsid)
-inner join hierarchy h4 on (h3.id = h4.parentid)
-inner join structureddategroup sd on (h4.id = sd.id)
-inner join collectionspace_core core on core.id=co1.id
-left outer join hierarchy h5 on (co1.id = h5.parentid)
-inner join objectnamegroup ong on (ong.id=h5.id)
-where misc.lifecyclestate <> 'deleted'
-and h4.name = 'collectionobjects_pahma:pahmaFieldCollectionDateGroupList'
-and core.tenantid=$P{tenantid}
-and h1.name=$P{csid}
-order by objectnumber]]>
+		<![CDATA[SELECT
+	cc.objectnumber AS objectNumber,
+	ocg.objectCount AS objectCount,
+	GETDISPL(cc.computedcurrentlocation) AS location1,
+	GETDISPL(cc.computedcurrentlocation) AS location2,
+	GETDISPL(cc.computedcurrentlocation) AS currLocation,
+	'geography' AS Geography,
+	'culture' AS Culture,
+	'filecode' AS FileCode,
+	COALESCE(ong.objectName, '') AS objectName
+FROM groups_common gc
+LEFT OUTER JOIN hierarchy hgc ON (gc.id = hgc.id)
+JOIN relations_common rc ON (hgc.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+LEFT OUTER JOIN hierarchy hcc ON (rc.objectcsid = hcc.name)
+LEFT OUTER JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	and hong.pos = 0)
+inner join objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+JOIN misc m ON (cc.id = m.id
+	AND m.lifecyclestate <> 'deleted')
+WHERE hgc.name = $P{csid}
+ORDER BY cc.objectnumber]]>
 	</queryString>
 	<field name="objectNumber" class="java.lang.String"/>
-	<field name="objectName" class="java.lang.String"/>
-	<field name="groupTitle" class="java.lang.String"/>
-	<field name="scopeNote" class="java.lang.String"/>
-	<field name="currLocation" class="java.lang.String"/>
-	<field name="componentNumber" class="java.lang.String"/>
-	<field name="componentName" class="java.lang.String"/>
 	<field name="objectCount" class="java.lang.Integer"/>
-	<field name="fieldcollectiondate" class="java.lang.String"/>
-	<field name="description" class="java.lang.String"/>
 	<field name="location1" class="java.lang.String"/>
 	<field name="location2" class="java.lang.String"/>
+	<field name="currLocation" class="java.lang.String"/>
 	<field name="Geography" class="java.lang.String"/>
 	<field name="Culture" class="java.lang.String"/>
 	<field name="FileCode" class="java.lang.String"/>
+	<field name="objectName" class="java.lang.String"/>
 	<group name="currLocation">
 		<groupExpression><![CDATA[$F{currLocation}]]></groupExpression>
 		<groupHeader>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectEntry-groupResearcher.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectEntry-groupResearcher.jrxml
@@ -7,40 +7,42 @@
 		<defaultValueExpression><![CDATA["0cca1640-6014-4b3e-8453"]]></defaultValueExpression>
 	</parameter>
 	<queryString>
-		<![CDATA[SELECT  inc.entrynumber entryNumber,
-        inc.entrydate entryDate,
-        inc.entrynote entryNote,
-        h1.name AS "csid",
-        co.objectnumber AS "Museum No.",
-        cp.sortableobjectnumber AS "sort",
-        ong.objectName AS "Name",
-        bd.item AS "Description",
-        CASE WHEN (fcp.item IS NOT NULL AND fcp.item <> '')
-          THEN regexp_replace(fcp.item, '^.*\)''(.*)''$', '\1') END AS "Site",
-        co.numberofobjects objectCount,
-        case when (apg.assocpeople is not null and apg.assocpeople <> '') then
-          regexp_replace(apg.assocpeople, '^.*\)''(.*)''$', '\1')
-        end as culturalgroup
-FROM intakes_common inc
-JOIN hierarchy h1 ON (inc.id=h1.id)
-JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)
-JOIN hierarchy h2 ON (rc1.objectcsid=h2.name)
-JOIN collectionobjects_common co ON (h2.id=co.id)
-JOIN collectionobjects_pahma cp ON (co.id=cp.id)
-join collectionobjects_anthropology ca on (co.id=ca.id)
-
-LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
-
-left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:assocPeopleGroupList')
-left outer join assocpeoplegroup apg on (apg.id=h4.id)
-
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
-
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (co.id=fcp.id AND fcp.pos=0)
-
-WHERE rc1.subjectcsid = $P{csid}
-
+		<![CDATA[SELECT
+	ic.entrynumber AS entrynumber,
+	ic.entrydate AS entrydate,
+	ic.entrynote AS entrynote,
+	hic.name AS csid,
+	cc.objectnumber AS "Museum No.",
+	cp.sortableobjectnumber AS "sort",
+	ong.objectName AS "Name",
+	bd.item AS "Description",
+	getdispl(fcp.item) AS "Site",
+	ocg.objectCount AS objectcount,
+	getdispl(apg.assocpeople) AS culturalgroup
+FROM intakes_common ic
+JOIN hierarchy hic ON (ic.id = hic.id)
+JOIN relations_common rc ON (hic.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+JOIN hierarchy hcc ON (rc.objectcsid = hcc.name)
+JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hapg ON (cc.id = hapg.parentid
+	AND hapg.primarytype = 'assocPeopleGroup'
+	AND hapg.pos = 0)
+LEFT OUTER JOIN assocpeoplegroup apg ON (hapg.id = apg.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = cc.id
+	AND bd.pos = 0)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id
+	AND fcp.pos = 0)
+WHERE hic.name = $P{csid}
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="entrynumber" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectExit,Wide,Culture.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectExit,Wide,Culture.jrxml
@@ -8,40 +8,42 @@
 	</parameter>
 	<queryString>
 		<![CDATA[SELECT
-oec.exitnumber exitNumber,
-oec.exitnote exitNote,
-h1.name AS "csid",
-co.objectnumber AS "Museum No.",
-cp.sortableobjectnumber AS "sort",
-ong.objectName AS "Name",
-bd.item AS "Description",
-CASE WHEN (fcp.item IS NOT NULL AND fcp.item <> '')
- THEN regexp_replace(fcp.item, '^.*\)''(.*)''$', '\1') END AS "Site",
-co.numberofobjects objectCount,
-case when (apg.assocpeople is not null and apg.assocpeople <> '') then
- regexp_replace(apg.assocpeople, '^.*\)''(.*)''$', '\1')
-end as culturalgroup
+	oec.exitnumber as exitnumber,
+	oec.exitnote exitnote,
+	hoec.name AS csid,
+	cc.objectnumber AS "Museum No.",
+	cp.sortableobjectnumber AS "sort",
+	ong.objectName AS "Name",
+	bd.item AS "Description",
+	GETDISPL(fcp.item) AS "Site",
+	ocg.objectCount AS objectcount,
+	GETDISPL(apg.assocpeople) AS culturalgroup
 FROM objectexit_common oec
-JOIN hierarchy h1 ON (oec.id=h1.id)
-JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)
-JOIN hierarchy h2 ON (rc1.objectcsid=h2.name)
-JOIN collectionobjects_common co ON (h2.id=co.id)
-LEFT OUTER JOIN collectionobjects_pahma cp ON (co.id=cp.id)
-LEFT OUTER JOIN collectionobjects_anthropology ca on (co.id=ca.id)
-
-LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
-
-left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:assocPeopleGroupList')
-left outer join assocpeoplegroup apg on (apg.id=h4.id)
-
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
-
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (co.id=fcp.id AND fcp.pos=0)
-
-JOIN misc ms ON (co.id=ms.id AND ms.lifecyclestate <> 'deleted')
-WHERE rc1.subjectcsid = $P{csid}
-
+JOIN hierarchy hoec ON (oec.id = hoec.id)
+JOIN relations_common rc ON (hoec.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+JOIN hierarchy hcc ON (rc.objectcsid = hcc.name)
+JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hapg on (cc.id = hapg.parentid
+	AND hapg.primarytype = 'assocPeopleGroup'
+	AND hapg.pos = 0)
+LEFT OUTER JOIN assocpeoplegroup apg on (hapg.id = apg.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = cc.id
+	AND bd.pos = 0)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id
+	AND fcp.pos = 0)
+JOIN misc m ON (cc.id = m.id
+	AND m.lifecyclestate <> 'deleted')
+WHERE hoec.name = $P{csid}
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="exitnumber" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectExit-groupResearcher.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectExit-groupResearcher.jrxml
@@ -8,39 +8,42 @@
 	</parameter>
 	<queryString>
 		<![CDATA[SELECT
-oec.exitnumber exitNumber,
-oec.exitnote exitNote,
-h1.name AS "csid",
-co.objectnumber AS "Museum No.",
-cp.sortableobjectnumber AS "sort",
-ong.objectName AS "Name",
-bd.item AS "Description",
-CASE WHEN (fcp.item IS NOT NULL AND fcp.item <> '')
- THEN regexp_replace(fcp.item, '^.*\)''(.*)''$', '\1') END AS "Site",
-co.numberofobjects objectCount,
-case when (apg.assocpeople is not null and apg.assocpeople <> '') then
- regexp_replace(apg.assocpeople, '^.*\)''(.*)''$', '\1')
-end as culturalgroup
+	oec.exitnumber AS exitnumber,
+	oec.exitnote AS exitnote,
+	hoec.name AS csid,
+	cc.objectnumber AS "Museum No.",
+	cp.sortableobjectnumber AS "sort",
+	ong.objectName AS "Name",
+	bd.item AS "Description",
+	GETDISPL(fcp.item) AS "Site",
+	ocg.objectCount AS objectcount,
+	GETDISPL(apg.assocpeople) AS culturalgroup
 FROM objectexit_common oec
-JOIN hierarchy h1 ON (oec.id=h1.id)
-JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)
-JOIN hierarchy h2 ON (rc1.objectcsid=h2.name)
-JOIN collectionobjects_common co ON (h2.id=co.id)
-JOIN collectionobjects_pahma cp ON (co.id=cp.id)
-join collectionobjects_anthropology ca on (co.id=ca.id)
-
-LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
-
-left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:assocPeopleGroupList')
-left outer join assocpeoplegroup apg on (apg.id=h4.id)
-
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
-
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (co.id=fcp.id AND fcp.pos=0)
-
-WHERE rc1.subjectcsid = $P{csid}
-
+JOIN hierarchy hoec ON (oec.id = hoec.id)
+JOIN relations_common rc ON (hoec.name = rc.subjectcsid
+        AND rc.objectdocumenttype = 'CollectionObject')
+JOIN hierarchy hcc ON (rc.objectcsid = hcc.name)
+JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hapg ON (cc.id = hapg.parentid
+	AND hapg.primarytype = 'assocPeopleGroup'
+	AND hapg.pos = 0)
+LEFT OUTER JOIN assocpeoplegroup apg ON (hapg.id = apg.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = cc.id
+	AND bd.pos = 0)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id
+	AND fcp.pos = 0)
+JOIN misc m ON (cc.id = m.id
+        AND m.lifecyclestate <> 'deleted')
+WHERE hoec.name = $P{csid}
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="exitnumber" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectsInClaim,Wide,Culture.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectsInClaim,Wide,Culture.jrxml
@@ -7,51 +7,52 @@
 		<defaultValueExpression><![CDATA["0cca1640-6014-4b3e-8453"]]></defaultValueExpression>
 	</parameter>
 	<queryString>
-		<![CDATA[SELECT  clc.claimnumber claimNumber,
-        cla.claimname claimName,
-        cac.item claimNote,
-        h1.name AS "csid",
-        co.objectnumber AS "Museum No.",
-        cp.sortableobjectnumber AS "sort",
-        ong.objectName AS "Name",
-        bd.item AS "Description",
-        CASE WHEN (fcp.item IS NOT NULL AND fcp.item <> '')
-          THEN regexp_replace(fcp.item, '^.*\)''(.*)''$', '\1') END AS "Site",
-        co.numberofobjects objectCount,
-        case when (apg.assocpeople is not null and apg.assocpeople <> '') then
-          regexp_replace(apg.assocpeople, '^.*\)''(.*)''$', '\1')
-        end as culturalgroup
+		<![CDATA[SELECT
+	clc.claimnumber AS claimnumber,
+	cla.claimname AS claimname,
+	cac.item AS claimnote,
+	cc.objectnumber AS "Museum No.",
+	cp.sortableobjectnumber,
+	ong.objectName AS "Name",
+	bd.item AS "Description",
+	GETDISPL(fcp.item) AS "Site",
+	ocg.objectCount AS objectcount,
+	GETDISPL(apg.assocpeople) AS culturalgroup
 FROM claims_common clc
-JOIN hierarchy h1 ON (clc.id=h1.id)
-JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)
-JOIN hierarchy h2 ON (rc1.objectcsid=h2.name)
-JOIN collectionobjects_common co ON (h2.id=co.id)
-LEFT OUTER JOIN collectionobjects_pahma cp ON (co.id=cp.id)
-LEFT OUTER JOIN collectionobjects_anthropology ca on (co.id=ca.id)
-LEFT OUTER JOIN claims_anthropology cla on (clc.id=cla.id)
-LEFT OUTER JOIN claims_anthropology_claimnotelist cac ON (clc.id = cac.id AND cac.pos=0)
-
-LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
-
-left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:assocPeopleGroupList')
-left outer join assocpeoplegroup apg on (apg.id=h4.id)
-
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
-
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (co.id=fcp.id AND fcp.pos=0)
-
-JOIN misc ms ON (co.id=ms.id AND ms.lifecyclestate <> 'deleted')
-WHERE rc1.subjectcsid =$P{csid}
-
+JOIN hierarchy hclc ON (clc.id = hclc.id)
+JOIN relations_common rc ON (hclc.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+JOIN hierarchy hcc ON (rc.objectcsid = hcc.name)
+JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN claims_anthropology cla ON (clc.id = cla.id)
+LEFT OUTER JOIN claims_anthropology_claimnotelist cac ON (clc.id = cac.id
+	AND cac.pos = 0)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hapg ON (cc.id = hapg.parentid
+	AND hapg.primarytype = 'assocPeopleGroup'
+	AND hapg.pos = 0)
+LEFT OUTER JOIN assocpeoplegroup apg ON (hapg.id = apg.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = cc.id
+	AND bd.pos = 0)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id
+	AND fcp.pos = 0)
+JOIN misc m ON (cc.id = m.id
+	AND m.lifecyclestate <> 'deleted')
+WHERE hclc.name = $P{csid}
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="claimnumber" class="java.lang.String"/>
 	<field name="claimname" class="java.lang.String"/>
 	<field name="claimnote" class="java.lang.String"/>
-	<field name="csid" class="java.lang.String"/>
 	<field name="Museum No." class="java.lang.String"/>
-	<field name="sort" class="java.lang.String"/>
 	<field name="Name" class="java.lang.String"/>
 	<field name="Description" class="java.lang.String"/>
 	<field name="Site" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectsInClaim-groupResearcher.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectsInClaim-groupResearcher.jrxml
@@ -7,42 +7,46 @@
 		<defaultValueExpression><![CDATA["0cca1640-6014-4b3e-8453"]]></defaultValueExpression>
 	</parameter>
 	<queryString>
-		<![CDATA[SELECT  clc.claimnumber claimNumber,
-        cla.claimname claimName,
-        cac.item claimNote,
-        h1.name AS "csid",
-        co.objectnumber AS "Museum No.",
-        cp.sortableobjectnumber AS "sort",
-        ong.objectName AS "Name",
-        bd.item AS "Description",
-        CASE WHEN (fcp.item IS NOT NULL AND fcp.item <> '')
-          THEN regexp_replace(fcp.item, '^.*\)''(.*)''$', '\1') END AS "Site",
-        co.numberofobjects objectCount,
-        case when (apg.assocpeople is not null and apg.assocpeople <> '') then
-          regexp_replace(apg.assocpeople, '^.*\)''(.*)''$', '\1')
-        end as culturalgroup
+		<![CDATA[SELECT
+	clc.claimnumber AS claimnumber,
+	cla.claimname AS claimname,
+	cac.item AS claimnote,
+	hclc.name AS csid,
+	cc.objectnumber AS "Museum No.",
+	cp.sortableobjectnumber AS "sort",
+	ong.objectName AS "Name",
+	bd.item AS "Description",
+	GETDISPL(fcp.item) AS "Site",
+	ocg.objectCount objectcount,
+	GETDISPL(apg.assocpeople) AS culturalgroup
 FROM claims_common clc
-JOIN hierarchy h1 ON (clc.id=h1.id)
-JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)
-JOIN hierarchy h2 ON (rc1.objectcsid=h2.name)
-JOIN collectionobjects_common co ON (h2.id=co.id)
-JOIN collectionobjects_pahma cp ON (co.id=cp.id)
-join collectionobjects_anthropology ca on (co.id=ca.id)
-JOIN claims_anthropology cla on (clc.id=cla.id)
-LEFT OUTER JOIN claims_anthropology_claimnotelist cac ON (clc.id = cac.id AND cac.pos=0)
-
-LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
-
-left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:assocPeopleGroupList')
-left outer join assocpeoplegroup apg on (apg.id=h4.id)
-
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
-
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (co.id=fcp.id AND fcp.pos=0)
-
-WHERE rc1.subjectcsid =$P{csid}
-
+JOIN hierarchy hclc ON (clc.id = hclc.id)
+JOIN relations_common rc ON (hclc.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+JOIN hierarchy hcc ON (rc.objectcsid = hcc.name
+	AND rc.objectdocumenttype = 'CollectionObject')
+JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+JOIN claims_anthropology cla ON (clc.id = cla.id)
+LEFT OUTER JOIN claims_anthropology_claimnotelist cac ON (clc.id = cac.id
+	AND cac.pos = 0)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hapg ON (cc.id = hapg.parentid
+	AND hapg.primarytype = 'assocPeopleGroup'
+	AND hapg.pos = 0)
+LEFT OUTER JOIN assocpeoplegroup apg ON (hapg.id = apg.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = cc.id
+	AND bd.pos = 0)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id
+	AND fcp.pos = 0)
+WHERE hclc.name = $P{csid}
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="claimnumber" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectsInLoan,Wide,Culture.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectsInLoan,Wide,Culture.jrxml
@@ -7,45 +7,47 @@
 		<defaultValueExpression><![CDATA["0cca1640-6014-4b3e-8453"]]></defaultValueExpression>
 	</parameter>
 	<queryString>
-		<![CDATA[SELECT  lic.loaninnumber loanInNumber,
-        case when (lg.lender is not null and lg.lender <> '') then
-         regexp_replace(lg.lender, '^.*\)''(.*)''$', '\1')
-         else ''
-        end AS lender,
-        h1.name AS "csid",
-        co.objectnumber AS "Museum No.",
-        cp.sortableobjectnumber AS "sort",
-        ong.objectName AS "Name",
-        bd.item AS "Description",
-        CASE WHEN (fcp.item IS NOT NULL AND fcp.item <> '')
-          THEN regexp_replace(fcp.item, '^.*\)''(.*)''$', '\1') END AS "Site",
-        co.numberofobjects objectCount,
-        case when (apg.assocpeople is not null and apg.assocpeople <> '') then
-          regexp_replace(apg.assocpeople, '^.*\)''(.*)''$', '\1')
-        end as culturalgroup
+		<![CDATA[SELECT
+	lic.loaninnumber AS loaninnumber,
+	COALESCE(GETDISPL(lg.lender), '') AS lender,
+	hlic.name AS csid,
+	cc.objectnumber AS "Museum No.",
+	cp.sortableobjectnumber AS "sort",
+	ong.objectName AS "Name",
+	bd.item AS "Description",
+	GETDISPL(fcp.item) AS "Site",
+	ocg.objectCount AS objectcount,
+	GETDISPL(apg.assocpeople) AS culturalgroup
 FROM loansin_common lic
-JOIN hierarchy h1 ON (lic.id=h1.id)
-JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)
-JOIN hierarchy h2 ON (rc1.objectcsid=h2.name)
-JOIN collectionobjects_common co ON (h2.id=co.id)
-LEFT OUTER JOIN collectionobjects_pahma cp ON (co.id=cp.id)
-LEFT OUTER JOIN collectionobjects_anthropology ca on (co.id=ca.id)
-
-LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
-
-left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:assocPeopleGroupList')
-left outer join assocpeoplegroup apg on (apg.id=h4.id)
-left outer join hierarchy hlgl on (lic.id=hlgl.parentid and hlgl.pos=0 and hlgl.name='loansin_common:lenderGroupList')
-left outer join lendergroup lg on (lg.id=hlgl.id)
-
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
-
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (co.id=fcp.id AND fcp.pos=0)
-
-JOIN misc ms ON (co.id=ms.id AND ms.lifecyclestate <> 'deleted')
-WHERE rc1.subjectcsid =$P{csid}
-
+JOIN hierarchy hlic ON (lic.id = hlic.id)
+JOIN relations_common rc ON (hlic.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+JOIN hierarchy hcc ON (rc.objectcsid = hcc.name)
+JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hapg ON (cc.id = hapg.parentid
+	AND hapg.primarytype = 'assocPeopleGroup'
+	AND hapg.pos = 0)
+LEFT OUTER JOIN assocpeoplegroup apg ON (hapg.id = apg.id)
+LEFT OUTER JOIN hierarchy hlg ON (lic.id = hlg.parentid
+	AND hlg.primarytype = 'lenderGroup'
+	AND hlg.pos = 0)
+LEFT OUTER JOIN lendergroup lg ON (hlg.id = lg.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = cc.id
+	AND bd.pos = 0)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id
+	AND fcp.pos = 0)
+JOIN misc m ON (cc.id = m.id
+	AND m.lifecyclestate <> 'deleted')
+WHERE hlic.name = $P{csid}
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="loaninnumber" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectsInLoan-groupResearcher.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectsInLoan-groupResearcher.jrxml
@@ -7,44 +7,46 @@
 		<defaultValueExpression><![CDATA["0cca1640-6014-4b3e-8453"]]></defaultValueExpression>
 	</parameter>
 	<queryString>
-		<![CDATA[SELECT  lic.loaninnumber loanInNumber,
-        case when (lg.lender is not null and lg.lender <> '') then
-         regexp_replace(lg.lender, '^.*\)''(.*)''$', '\1')
-         else ''
-        end AS lender,
-        h1.name AS "csid",
-        co.objectnumber AS "Museum No.",
-        cp.sortableobjectnumber AS "sort",
-        ong.objectName AS "Name",
-        bd.item AS "Description",
-        CASE WHEN (fcp.item IS NOT NULL AND fcp.item <> '')
-          THEN regexp_replace(fcp.item, '^.*\)''(.*)''$', '\1') END AS "Site",
-        co.numberofobjects objectCount,
-        case when (apg.assocpeople is not null and apg.assocpeople <> '') then
-          regexp_replace(apg.assocpeople, '^.*\)''(.*)''$', '\1')
-        end as culturalgroup
+		<![CDATA[SELECT
+	lic.loaninnumber loanInNumber,
+	COALESCE(GETDISPL(lg.lender), '') AS lender,
+	hlic.name AS csid,
+	co.objectnumber AS "Museum No.",
+	cp.sortableobjectnumber AS "sort",
+	ong.objectName AS "Name",
+	bd.item AS "Description",
+	GETDISPL(fcp.item) AS "Site",
+	ocg.objectCount AS objectcount,
+	GETDISPL(apg.assocpeople) AS culturalgroup
 FROM loansin_common lic
-JOIN hierarchy h1 ON (lic.id=h1.id)
-JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)
-JOIN hierarchy h2 ON (rc1.objectcsid=h2.name)
-JOIN collectionobjects_common co ON (h2.id=co.id)
-JOIN collectionobjects_pahma cp ON (co.id=cp.id)
-join collectionobjects_anthropology ca on (co.id=ca.id)
-
-LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
-
-left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:assocPeopleGroupList')
-left outer join assocpeoplegroup apg on (apg.id=h4.id)
-left outer join hierarchy hlgl on (lic.id=hlgl.parentid and hlgl.pos=0 and hlgl.name='loansin_common:lenderGroupList')
-left outer join lendergroup lg on (lg.id=hlgl.id)
-
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
-
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (co.id=fcp.id AND fcp.pos=0)
-
-WHERE rc1.subjectcsid =$P{csid}
-
+JOIN hierarchy hlic ON (lic.id = hlic.id)
+JOIN relations_common rc ON (hlic.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+JOIN hierarchy hcc ON (rc.objectcsid = hcc.name)
+JOIN collectionobjects_common co ON (hcc.id = co.id)
+JOIN collectionobjects_pahma cp ON (co.id = cp.id)
+JOIN collectionobjects_anthropology ca ON (co.id = ca.id)
+LEFT OUTER JOIN hierarchy hong ON (co.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hapg ON (co.id = hapg.parentid
+	AND hapg.primarytype = 'assocPeopleGroup'
+	AND hapg.pos = 0)
+LEFT OUTER JOIN assocpeoplegroup apg ON (hapg.id = apg.id)
+LEFT OUTER JOIN hierarchy hlg ON (lic.id = hlg.parentid
+	AND hlg.primarytype = 'lenderGroup'
+	AND hlg.pos = 0)
+LEFT OUTER JOIN lendergroup lg ON (hlg.id = lg.id)
+LEFT OUTER JOIN hierarchy hocg ON (co.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = co.id
+	AND bd.pos = 0)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (co.id = fcp.id
+	AND fcp.pos = 0)
+WHERE hlic.name = $P{csid}
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="loaninnumber" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectsOutLoan,Wide,Culture.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectsOutLoan,Wide,Culture.jrxml
@@ -7,43 +7,43 @@
 		<defaultValueExpression><![CDATA["0cca1640-6014-4b3e-8453"]]></defaultValueExpression>
 	</parameter>
 	<queryString>
-		<![CDATA[SELECT  loc.loanoutnumber loanOutNumber,
-        case when (loc.borrower is not null and loc.borrower <> '') then
-        regexp_replace(loc.borrower, '^.*\)''(.*)''$', '\1')
-        else ''
-        end AS borrower,
-        h1.name AS "csid",
-        co.objectnumber AS "Museum No.",
-        cp.sortableobjectnumber AS "sort",
-        ong.objectName AS "Name",
-        bd.item AS "Description",
-        CASE WHEN (fcp.item IS NOT NULL AND fcp.item <> '')
-          THEN regexp_replace(fcp.item, '^.*\)''(.*)''$', '\1') END AS "Site",
-        co.numberofobjects objectCount,
-        case when (apg.assocpeople is not null and apg.assocpeople <> '') then
-          regexp_replace(apg.assocpeople, '^.*\)''(.*)''$', '\1')
-        end as culturalgroup
+		<![CDATA[SELECT
+	loc.loanoutnumber AS loanoutnumber,
+	COALESCE(GETDISPL(loc.borrower), '') AS borrower,
+	hloc.name AS csid,
+	cc.objectnumber AS "Museum No.",
+	cp.sortableobjectnumber AS "sort",
+	ong.objectName AS "Name",
+	bd.item AS "Description",
+	GETDISPL(fcp.item) AS "Site",
+	ocg.objectCount AS objectcount,
+	GETDISPL(apg.assocpeople) AS culturalgroup
 FROM loansout_common loc
-JOIN hierarchy h1 ON (loc.id=h1.id)
-JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)
-JOIN hierarchy h2 ON (rc1.objectcsid=h2.name)
-JOIN collectionobjects_common co ON (h2.id=co.id)
-LEFT OUTER JOIN collectionobjects_pahma cp ON (co.id=cp.id)
-LEFT OUTER JOIN collectionobjects_anthropology ca on (co.id=ca.id)
-
-LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
-
-left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:assocPeopleGroupList')
-left outer join assocpeoplegroup apg on (apg.id=h4.id)
-
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
-
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (co.id=fcp.id AND fcp.pos=0)
-
-JOIN misc ms ON (co.id=ms.id AND ms.lifecyclestate <> 'deleted')
-WHERE rc1.subjectcsid = $P{csid}
-
+JOIN hierarchy hloc ON (loc.id = hloc.id)
+JOIN relations_common rc ON (hloc.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+JOIN hierarchy hcc ON (rc.objectcsid = hcc.name)
+JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hapg ON (cc.id = hapg.parentid
+	AND hapg.primarytype = 'assocPeopleGroup'
+	AND hapg.pos = 0)
+LEFT OUTER JOIN assocpeoplegroup apg ON (hapg.id = apg.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = cc.id
+	AND bd.pos = 0)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id
+	AND fcp.pos = 0)
+JOIN misc ms ON (cc.id = ms.id
+	AND ms.lifecyclestate <> 'deleted')
+WHERE hloc.name = $P{csid}
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="loanoutnumber" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectsOutLoan-groupResearcher.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/ObjectsOutLoan-groupResearcher.jrxml
@@ -7,42 +7,44 @@
 		<defaultValueExpression><![CDATA["0cca1640-6014-4b3e-8453"]]></defaultValueExpression>
 	</parameter>
 	<queryString>
-		<![CDATA[SELECT  loc.loanoutnumber loanOutNumber,
-        case when (loc.borrower is not null and loc.borrower <> '') then
-        regexp_replace(loc.borrower, '^.*\)''(.*)''$', '\1')
-        else ''
-        end AS borrower,
-        h1.name AS "csid",
-        co.objectnumber AS "Museum No.",
-        cp.sortableobjectnumber AS "sort",
-        ong.objectName AS "Name",
-        bd.item AS "Description",
-        CASE WHEN (fcp.item IS NOT NULL AND fcp.item <> '')
-          THEN regexp_replace(fcp.item, '^.*\)''(.*)''$', '\1') END AS "Site",
-        co.numberofobjects objectCount,
-        case when (apg.assocpeople is not null and apg.assocpeople <> '') then
-          regexp_replace(apg.assocpeople, '^.*\)''(.*)''$', '\1')
-        end as culturalgroup
+		<![CDATA[SELECT
+	loc.loanoutnumber AS loanoutnumber,
+	COALESCE(GETDISPL(loc.borrower), '') AS borrower,
+	hloc.name AS csid,
+	cc.objectnumber AS "Museum No.",
+	cp.sortableobjectnumber AS "sort",
+	ong.objectName AS "Name",
+	bd.item AS "Description",
+	GETDISPL(fcp.item) AS "Site",
+	ocg.objectCount AS objectcount,
+	GETDISPL(apg.assocpeople) AS culturalgroup
 FROM loansout_common loc
-JOIN hierarchy h1 ON (loc.id=h1.id)
-JOIN relations_common rc1 ON (h1.name=rc1.subjectcsid)
-JOIN hierarchy h2 ON (rc1.objectcsid=h2.name)
-JOIN collectionobjects_common co ON (h2.id=co.id)
-JOIN collectionobjects_pahma cp ON (co.id=cp.id)
-join collectionobjects_anthropology ca on (co.id=ca.id)
-
-LEFT OUTER JOIN hierarchy h3 ON (co.id = h3.parentid AND h3.primarytype='objectNameGroup' AND h3.pos=0)
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id=h3.id)
-
-left outer join hierarchy h4 on (co.id=h4.parentid and h4.pos=0 and h4.name='collectionobjects_common:assocPeopleGroupList')
-left outer join assocpeoplegroup apg on (apg.id=h4.id)
-
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=co.id and bd.pos=0)
-
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (co.id=fcp.id AND fcp.pos=0)
-
-WHERE rc1.subjectcsid = $P{csid}
-
+JOIN hierarchy hloc ON (loc.id = hloc.id)
+JOIN relations_common rc ON (hloc.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+JOIN hierarchy hcc ON (rc.objectcsid = hcc.name)
+JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+JOIN collectionobjects_anthropology ca ON (cc.id = ca.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hapg ON (cc.id = hapg.parentid
+	AND hapg.primarytype = 'assocPeopleGroup'
+	AND hapg.pos = 0)
+LEFT OUTER JOIN assocpeoplegroup apg ON (hapg.id = apg.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = cc.id
+	AND bd.pos = 0)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id
+	AND fcp.pos = 0)
+JOIN misc m ON (cc.id = m.id
+        AND m.lifecyclestate <> 'deleted')
+WHERE hloc.name = $P{csid}
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="loanoutnumber" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/PlaceReport.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/PlaceReport.jrxml
@@ -15,58 +15,47 @@
 		<defaultValueExpression><![CDATA["b6d49fa9-788a-477a-993e"]]></defaultValueExpression>
 	</parameter>
 	<queryString language="SQL">
-		<![CDATA[select
-findcurrentlocation(co1.id) currLocation,
-co1.numberofobjects objectCount,
-ptg.termname as site,
-substring(pcoc.item, position(')''' in pcoc.item)+2, length(pcoc.item)-position(')''' in pcoc.item)-2) as fieldcollectionplace,
-g.title groupTitle,
-(case when g.scopenote is Null then '' else g.scopenote end) scopeNote,
-co1.id objectid,
-co1.objectnumber objectNumber,
-cop.sortableobjectnumber,
-(case when ong.objectName is NULL then '' else ong.objectName end) objectName,
-sd.datedisplaydate fieldCollectionDate,
-(case when bd.item is NULL then '' else bd.item end) description,
-r.subjectcsid relationsubjectid,
-r.objectcsid,
-h4.id h4id,
-h4.parentid h4pid,
-h3.id h3id,
-h3.parentid h3pid,
-misc.lifecyclestate lifecyclestate
-from groups_common g
-left outer join hierarchy h1 on (g.id = h1.id)
-inner join relations_common r on (h1.name = r.objectcsid)
-left outer join hierarchy h2 on (r.subjectcsid = h2.name)
-left outer join collectionobjects_common co1 on (h2.id = co1.id)
-left outer join collectionobjects_pahma cop on (h2.id = cop.id)
-left outer join collectionobjects_common_briefdescriptions bd on (co1.id = bd.id AND bd.pos = 0)
-inner join misc on misc.id = co1.id
-inner join hierarchy h3 on (h3.name = r.subjectcsid)
-inner join hierarchy h4 on (h3.id = h4.parentid)
-inner join structureddategroup sd on (h4.id = sd.id)
-inner join collectionspace_core core on core.id=co1.id
-left outer join hierarchy h5 on (co1.id = h5.parentid)
-inner join objectnamegroup ong on (ong.id=h5.id)
-
-left outer join collectionobjects_pahma_pahmafieldcollectionplacelist pcoc on co1.id = pcoc.id
-left outer join places_common pc on pc.refname = pcoc.item
-left outer join hierarchy h6 on pc.id = h6.parentid
-join placetermgroup ptg on ptg.id = h6.id
-
-where misc.lifecyclestate <> 'deleted'
-and h4.name = 'collectionobjects_pahma:pahmaFieldCollectionDateGroupList'
-and core.tenantid=$P{tenantid}
-and h1.name= $P{csid}
-order by ptg.termname,cop.sortableobjectnumber]]>
+		<![CDATA[SELECT
+	GETDISPL(cc.computedcurrentlocation) AS currLocation,
+	cc.objectnumber AS objectNumber,
+	COALESCE(ong.objectName, '') AS objectName,
+	ocg.objectCount AS objectCount,
+	GETDISPL(pcoc.item) AS fieldcollectionplace,
+	COALESCE(bd.item, '') AS description,
+	COALESCE(gc.scopenote, '') AS scopeNote,
+	cp.sortableobjectnumber
+FROM groups_common gc
+JOIN hierarchy hgc ON (gc.id = hgc.id)
+JOIN relations_common rc ON (hgc.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+LEFT OUTER JOIN hierarchy hcc ON (rc.objectcsid = hcc.name)
+LEFT OUTER JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist pcoc ON (cc.id = pcoc.id)
+LEFT OUTER JOIN places_common pc ON (pcoc.item = pc.refname)
+LEFT OUTER JOIN hierarchy hptg ON (pc.id = hptg.parentid
+	AND hptg.primarytype = 'placeTermGroup')
+JOIN placetermgroup ptg ON (ptg.id = hptg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (cc.id = bd.id
+	AND bd.pos = 0)
+JOIN misc m ON (m.id = cc.id
+	AND m.lifecyclestate <> 'deleted')
+WHERE hgc.name = $P{csid}
+ORDER BY ptg.termname, cp.sortableobjectnumber]]>
 	</queryString>
+	<field name="currLocation" class="java.lang.String"/>
 	<field name="objectNumber" class="java.lang.String"/>
 	<field name="objectName" class="java.lang.String"/>
-	<field name="currLocation" class="java.lang.String"/>
 	<field name="objectCount" class="java.lang.Integer"/>
 	<field name="fieldcollectionplace" class="java.lang.String"/>
-	<field name="site" class="java.lang.String"/>
 	<field name="description" class="java.lang.String"/>
 	<field name="scopeNote" class="java.lang.String"/>
 	<group name="objectNumber">

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/SystematicInventory.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/SystematicInventory.jrxml
@@ -8,38 +8,41 @@
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Location Header" fontName="SansSerif" fontSize="12"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
-        <parameter name="Start Location" class="java.lang.String"/>
-        <parameter name="End Location" class="java.lang.String"/>
-        <parameter name="startLocDispl" class="java.lang.String">
-                <defaultValueExpression><![CDATA[$P{Start Location}.replaceAll("^.*\\)'(.*)'$", "$1")]]></defaultValueExpression>
-        </parameter>
-        <parameter name="endLocDispl" class="java.lang.String">
-                <defaultValueExpression><![CDATA[$P{End Location}.replaceAll("^.*\\)'(.*)'$", "$1")]]></defaultValueExpression>
-        </parameter>
+	<parameter name="Start Location" class="java.lang.String"/>
+	<parameter name="End Location" class="java.lang.String"/>
+	<parameter name="startLocDispl" class="java.lang.String">
+		<defaultValueExpression><![CDATA[$P{Start Location}.replaceAll("^.*\\)'(.*)'$", "$1")]]></defaultValueExpression>
+	</parameter>
+	<parameter name="endLocDispl" class="java.lang.String">
+		<defaultValueExpression><![CDATA[$P{End Location}.replaceAll("^.*\\)'(.*)'$", "$1")]]></defaultValueExpression>
+	</parameter>
 	<queryString>
 		<![CDATA[SELECT
-  CASE WHEN ca.computedcrate IS NULL
-    THEN GETDISPL(c.computedcurrentlocation)
-    ELSE GETDISPL(c.computedcurrentlocation) || ': ' || GETDISPL(ca.computedcrate)
-  END AS storageLocation,
-  CASE WHEN ca.computedcrate IS NULL
-    THEN REPLACE(GETDISPL(c.computedcurrentlocation), ' ', '0')
-    ELSE REPLACE(GETDISPL(c.computedcurrentlocation), ' ', '0') || '0'|| REPLACE(GETDISPL(ca.computedcrate), ' ', '0')
-  END AS locationKey,
-  GETDISPL(ca.computedcrate) AS computedCrate,
-  c.objectnumber AS objectNumber,
-  cp.sortableobjectnumber AS sortableObjectNumber,
-  c.numberofobjects AS objectCount,
-  ong.objectName AS objectName
-FROM collectionobjects_common c
-LEFT OUTER JOIN hierarchy h1 ON (c.id = h1.parentid AND h1.pos = 0 AND h1.name = 'collectionobjects_common:objectNameList')
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id = h1.id)
-LEFT OUTER JOIN collectionobjects_pahma cp ON (c.id = cp.id)
-LEFT OUTER JOIN collectionobjects_anthropology ca ON (c.id = ca.id)
-JOIN MISC ms ON (c.id = ms.id AND ms.lifecyclestate <> 'deleted')
-where REPLACE(GETDISPL(c.computedcurrentlocation), ' ', '0') >= REPLACE($P{startLocDispl}, ' ', '0')
-  AND REPLACE(GETDISPL(c.computedcurrentlocation), ' ', '0') <= REPLACE($P{endLocDispl}, ' ', '0')
-ORDER BY locationkey, sortableobjectnumber, objectName desc]]>
+	COALESCE(GETDISPL(cc.computedcurrentlocation) || ': ' || GETDISPL(ca.computedcrate),
+		GETDISPL(cc.computedcurrentlocation)) AS storageLocation,
+	COALESCE(REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0') || '0'|| REPLACE(GETDISPL(ca.computedcrate), ' ', '0'),
+		REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0')) AS locationKey,
+	GETDISPL(ca.computedcrate) AS computedCrate,
+	cc.objectnumber AS objectNumber,
+	cp.sortableobjectnumber AS sortableObjectNumber,
+	ocg.objectCount AS objectCount,
+	ong.objectName AS objectName
+FROM collectionobjects_common cc
+LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN collectionobjects_anthropology ca ON (cc.id = ca.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+JOIN misc m ON (cc.id = m.id
+	AND m.lifecyclestate <> 'deleted')
+WHERE REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0') >= REPLACE($P{startLocDispl}, ' ', '0')
+AND REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0') <= REPLACE($P{endLocDispl}, ' ', '0')
+ORDER BY locationKey, sortableObjectNumber, objectName DESC]]>
 	</queryString>
 	<field name="storageLocation" class="java.lang.String"/>
 	<field name="locationKey" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/SystematicInventoryHSR.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/SystematicInventoryHSR.jrxml
@@ -21,30 +21,34 @@
 	</parameter>
 	<queryString>
 		<![CDATA[SELECT
-  CASE WHEN ca.computedcrate IS NULL
-    THEN GETDISPL(c.computedcurrentlocation)
-    ELSE GETDISPL(c.computedcurrentlocation) || ': ' || GETDISPL(ca.computedcrate)
-  END AS storageLocation,
-  CASE WHEN ca.computedcrate is null
-    THEN REPLACE(GETDISPL(c.computedcurrentlocation), ' ', '0')
-    ELSE REPLACE(GETDISPL(c.computedcurrentlocation), ' ', '0') || '0' || REPLACE(GETDISPL(ca.computedcrate), ' ', '0')
-  END AS locationKey,
-  GETDISPL(ca.computedcrate) AS computedCrate,
-  c.objectnumber AS objectNumber,
-  cp.sortableobjectnumber AS sortableObjectNumber,
-  c.numberofobjects AS objectCount,
-  ong.objectName AS objectName,
-  bd.item AS briefDescription,
-  cp.inventorycount AS countNote
-FROM collectionobjects_common c
-LEFT OUTER JOIN hierarchy h1 ON (c.id = h1.parentid AND h1.pos = 0 AND h1.name = 'collectionobjects_common:objectNameList')
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id = h1.id)
-LEFT OUTER JOIN collectionobjects_pahma cp ON (c.id = cp.id)
-LEFT OUTER JOIN collectionobjects_anthropology ca ON (c.id = ca.id)
-JOIN misc ms ON (c.id = ms.id AND ms.lifecyclestate <> 'deleted')
-FULL OUTER JOIN collectionobjects_common_briefdescriptions bd ON bd.id = c.id AND bd.pos = 0
-WHERE REPLACE(GETDISPL(c.computedcurrentlocation), ' ', '0') >= REPLACE($P{startLocDispl}, ' ', '0')
-  AND REPLACE(GETDISPL(c.computedcurrentlocation), ' ', '0') <= REPLACE($P{endLocDispl}, ' ', '0')
+	COALESCE(GETDISPL(cc.computedcurrentlocation) || ': ' || GETDISPL(ca.computedcrate),
+		GETDISPL(cc.computedcurrentlocation)) AS storageLocation,
+	COALESCE(REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0') || '0'|| REPLACE(GETDISPL(ca.computedcrate), ' ', '0'),
+		REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0')) AS locationKey,
+	GETDISPL(ca.computedcrate) AS computedCrate,
+	cc.objectnumber AS objectNumber,
+	cp.sortableobjectnumber AS sortableObjectNumber,
+	ocg.objectCount AS objectCount,
+	ong.objectName AS objectName,
+	bd.item AS briefDescription,
+	ocg.objectCountNote AS countNote
+FROM collectionobjects_common cc
+LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN collectionobjects_anthropology ca ON (cc.id = ca.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+FULL OUTER JOIN collectionobjects_common_briefdescriptions bd ON bd.id = cc.id
+	AND bd.pos = 0
+JOIN misc m ON (cc.id = m.id
+	AND m.lifecyclestate <> 'deleted')
+WHERE REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0') >= REPLACE($P{startLocDispl}, ' ', '0')
+AND REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0') <= REPLACE($P{endLocDispl}, ' ', '0')
 ORDER BY locationKey, sortableObjectNumber, objectName desc]]>
 	</queryString>
 	<field name="storageLocation" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/govholdings.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/govholdings.jrxml
@@ -10,38 +10,60 @@
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
 	<parameter name="Agency" class="java.lang.String"/>
 	<queryString>
-		<![CDATA[SELECT DISTINCT cc.objectnumber AS objectnumber,
-        cp.sortableobjectnumber AS sortnumber,
-        cc.numberofobjects AS pieces,
-        ong.objectname AS objectname,
-        fcd.datedisplaydate AS collectiondate,
-        STRING_AGG(DISTINCT(ac.acquisitionreferencenumber), ', ') AS accno,
-        getdispl(fcp.item) AS site,
-        getdispl(pog.anthropologyplaceowner) AS siteowner,
-        pog.anthropologyplaceownershipnote AS ownershipnote,
-        pc.placenote AS placenote
+		<![CDATA[SELECT DISTINCT
+	cc.objectnumber AS objectnumber,
+	cp.sortableobjectnumber AS sortnumber,
+	ocg.objectCount AS pieces,
+	ong.objectname AS objectname,
+	fcd.datedisplaydate AS collectiondate,
+	STRING_AGG(DISTINCT(ac.acquisitionreferencenumber), ', ') AS accno,
+	getdispl(fcp.item) AS site,
+	getdispl(pog.anthropologyplaceowner) AS siteowner,
+	pog.anthropologyplaceownershipnote AS ownershipnote,
+	pc.placenote AS placenote
 FROM collectionobjects_common cc
 LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (fcp.id = cc.id)
-JOIN misc ms ON (ms.id = cc.id AND ms.lifecyclestate <> 'deleted')
-JOIN places_common pc ON (pc.refname = fcp.item)
-JOIN hierarchy hpog ON (hpog.parentid = pc.id AND hpog.primarytype = 'anthropologyPlaceOwnerGroup')
-JOIN anthropologyPlaceOwnerGroup pog ON (pog.id = hpog.id)
-FULL OUTER JOIN hierarchy hong ON (hong.parentid = cc.id
-        AND hong.name = 'collectionobjects_common:objectNameList' AND hong.pos = 0)
-FULL OUTER JOIN objectnamegroup ong ON (ong.id = hong.id)
-FULL OUTER JOIN hierarchy hcc ON (hcc.id = cc.id)
-FULL OUTER JOIN relations_common rc ON (rc.subjectcsid = hcc.name AND rc.objectdocumenttype = 'Acquisition')
-FULL OUTER JOIN hierarchy hac ON (hac.name = rc.objectcsid)
-FULL OUTER JOIN acquisitions_common ac ON (ac.id = hac.id)
-FULL OUTER JOIN hierarchy hfcd ON (hfcd.parentid = cc.id 
-        AND hfcd.name = 'collectionobjects_pahma:pahmaFieldCollectionDateGroupList' AND hfcd.pos = 0)
-FULL OUTER JOIN structureddategroup fcd ON (fcd.id = hfcd.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid 
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0 )
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN hierarchy hong ON (hong.parentid = cc.id 
+	AND hong.primarytype = 'objectNameGroup' 
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hfcd ON (hfcd.parentid = cc.id 
+	AND hfcd.name = 'collectionobjects_pahma:pahmaFieldCollectionDateGroupList' 
+	AND hfcd.pos = 0)
+LEFT OUTER JOIN structureddategroup fcd ON (fcd.id = hfcd.id)
+LEFT OUTER JOIN hierarchy hcc ON (hcc.id = cc.id)
+LEFT OUTER JOIN relations_common rc ON (hcc.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'Acquisition')
+LEFT OUTER JOIN hierarchy hac ON (rc.objectcsid = hac.name)
+LEFT OUTER JOIN acquisitions_common ac ON (hac.id = ac.id)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id)
+JOIN places_common pc ON (fcp.item = pc.refname)
+JOIN hierarchy hpog ON (pc.id = hpog.parentid
+	AND hpog.primarytype = 'anthropologyPlaceOwnerGroup')
+JOIN anthropologyPlaceOwnerGroup pog ON (hpog.id = pog.id)
+JOIN misc m ON (m.id = cc.id 
+	AND m.lifecyclestate <> 'deleted')
 WHERE pog.anthropologyplaceowner = $P{Agency}
-OR (pog.anthropologyplaceowner IS NULL AND pog.anthropologyplaceownershipnote ~ getdispl($P{Agency}))
-GROUP BY cc.objectnumber, cp.sortableobjectnumber, cc.numberofobjects, ong.objectname, fcd.datedisplaydate,
-        fcp.item, pog.anthropologyplaceowner, pog.anthropologyplaceownershipnote, pc.placenote
-ORDER BY getdispl(fcp.item), pog.anthropologyplaceownershipnote, cp.sortableobjectnumber]]>
+	OR (pog.anthropologyplaceowner IS NULL 
+		AND pog.anthropologyplaceownershipnote ~ getdispl($P{Agency}))
+GROUP BY 
+	cc.objectnumber, 
+	cp.sortableobjectnumber, 
+	ocg.objectcount, 
+	ong.objectname, 
+	fcd.datedisplaydate,
+	fcp.item, 
+	pog.anthropologyplaceowner, 
+	pog.anthropologyplaceownershipnote, 
+	pc.placenote
+ORDER BY 
+	getdispl(fcp.item), 
+	pog.anthropologyplaceownershipnote, 
+	cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="objectnumber" class="java.lang.String"/>
 	<field name="sortnumber" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/groupResearcherSummary.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/groupResearcherSummary.jrxml
@@ -5,33 +5,42 @@
 	<property name="ireport.y" value="0"/>
 	<parameter name="groupcsid" class="java.lang.String"/>
 	<queryString>
-		<![CDATA[SELECT gc.title AS groupTitle,
-        hco.name AS csid,
-        co.objectnumber AS museumNumber,
-        cp.sortableobjectnumber AS sortableObjectNumber,
-        ong.objectName AS objectName,
-        bd.item AS briefDescription,
-        CASE WHEN (fcp.item IS NOT NULL AND fcp.item <> '')
-          THEN GETDISPL(fcp.item) END AS site,
-        co.numberofobjects AS objectCount,
-        CASE WHEN (apg.assocpeople is not null and apg.assocpeople <> '')
-          THEN GETDISPL(apg.assocpeople)
-        END AS culturalGroup
+		<![CDATA[SELECT 
+	gc.title AS groupTitle,
+	hcc.name AS csid,
+	cc.objectnumber AS museumNumber,
+	cp.sortableobjectnumber AS sortableObjectNumber,
+	ong.objectName AS objectName,
+	bd.item AS briefDescription,
+	GETDISPL(fcp.item) AS site,
+	ocg.objectCount AS objectCount,
+	GETDISPL(apg.assocpeople) AS culturalGroup
 FROM groups_common gc
 JOIN hierarchy hgc ON (gc.id = hgc.id)
-JOIN relations_common rc ON (hgc.name = rc.subjectcsid)
-JOIN hierarchy hco ON (rc.objectcsid = hco.name)
-JOIN collectionobjects_common co ON (hco.id = co.id)
-LEFT OUTER JOIN collectionobjects_pahma cp ON (co.id = cp.id)
-LEFT OUTER JOIN collectionobjects_anthropology ca on (co.id = ca.id)
-LEFT OUTER JOIN hierarchy hong ON (co.id = hong.parentid AND hong.primarytype = 'objectNameGroup' AND hong.pos = 0)
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id = hong.id)
-LEFT OUTER JOIN hierarchy hapg on (co.id = hapg.parentid and hapg.pos = 0 and hapg.name = 'collectionobjects_common:assocPeopleGroupList')
-LEFT OUTER JOIN assocpeoplegroup apg on (apg.id = hapg.id)
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = co.id and bd.pos = 0)
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (co.id = fcp.id AND fcp.pos = 0)
-JOIN misc ms ON (co.id = ms.id AND ms.lifecyclestate <> 'deleted')
-WHERE rc.subjectcsid = $P{groupcsid}
+JOIN relations_common rc ON (hgc.name = rc.subjectcsid
+	AND rc.objectdocumenttype = 'CollectionObject')
+JOIN hierarchy hcc ON (rc.objectcsid = hcc.name)
+JOIN collectionobjects_common cc ON (hcc.id = cc.id)
+LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid 
+	AND hong.primarytype = 'objectNameGroup' 
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN hierarchy hapg ON (cc.id = hapg.parentid 
+	AND hapg.primarytype = 'assocPeopleGroup')
+	AND hapg.pos = 0 
+LEFT OUTER JOIN assocpeoplegroup apg ON (hapg.id = apg.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = cc.id 
+	AND bd.pos = 0)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (cc.id = fcp.id 
+	AND fcp.pos = 0)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid 
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+JOIN misc m ON (cc.id = m.id 
+	AND m.lifecyclestate <> 'deleted')
+WHERE hgc.name = $P{groupcsid}
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="groupTitle" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/keyinfobyloc.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/keyinfobyloc.jrxml
@@ -8,49 +8,51 @@
 	<style name="Column header" forecolor="#666666" fontName="SansSerif" fontSize="12" isBold="true"/>
 	<style name="Location Header" fontName="SansSerif" fontSize="12"/>
 	<style name="Detail" fontName="SansSerif" fontSize="12"/>
-        <parameter name="Start Location" class="java.lang.String"/>
-        <parameter name="End Location" class="java.lang.String"/>
-        <parameter name="startLocDispl" class="java.lang.String">
-                <defaultValueExpression><![CDATA[$P{Start Location}.replaceAll("^.*\\)'(.*)'$", "$1")]]></defaultValueExpression>
-        </parameter>
-        <parameter name="endLocDispl" class="java.lang.String">
-                <defaultValueExpression><![CDATA[$P{End Location}.replaceAll("^.*\\)'(.*)'$", "$1")]]></defaultValueExpression>
-        </parameter>
+	<parameter name="Start Location" class="java.lang.String"/>
+	<parameter name="End Location" class="java.lang.String"/>
+	<parameter name="startLocDispl" class="java.lang.String">
+		<defaultValueExpression><![CDATA[$P{Start Location}.replaceAll("^.*\\)'(.*)'$", "$1")]]></defaultValueExpression>
+	</parameter>
+	<parameter name="endLocDispl" class="java.lang.String">
+		<defaultValueExpression><![CDATA[$P{End Location}.replaceAll("^.*\\)'(.*)'$", "$1")]]></defaultValueExpression>
+	</parameter>
 	<queryString>
 		<![CDATA[SELECT
-  CASE WHEN ca.computedcrate IS NULL
-    THEN GETDISPL(c.computedcurrentlocation)
-    ELSE GETDISPL(c.computedcurrentlocation) || ' ' || GETDISPL(ca.computedcrate)
-  END AS storageLocation,
-  CASE WHEN ca.computedcrate IS NULL THEN REPLACE(GETDISPL(c.computedcurrentlocation), ' ', '0')
-    ELSE REPLACE(GETDISPL(c.computedcurrentlocation), ' ', '0') || '0' || REPLACE(GETDISPL(ca.computedcrate), ' ', '0')
-  END AS locationKey,
-  c.objectnumber AS objectNumber,
-  cp.sortableobjectnumber AS sortableObjectNumber,
-  c.numberofobjects AS objectCount,
-  ong.objectName AS objectName,
-  CASE WHEN (pfc.item IS NOT NULL AND pfc.item <> '')
-    THEN GETDISPL(pfc.item)
-  END AS fieldCollectionPlace,
-  CASE WHEN (apg.assocpeople is not null and apg.assocpeople <> '')
-    THEN GETDISPL(apg.assocpeople)
-  END AS culturalGroup,
-  CASE WHEN (pef.item IS NOT NULL AND pef.item <> '') THEN
-    GETDISPL(pef.item)
-  END AS ethnographicFileCode
-FROM collectionobjects_common c
-LEFT OUTER JOIN collectionobjects_pahma cp ON (c.id = cp.id)
-LEFT OUTER JOIN collectionobjects_anthropology ca ON (c.id = ca.id)
-LEFT OUTER JOIN hierarchy h5 ON (c.id = h5.parentid AND h5.pos = 0 AND h5.name = 'collectionobjects_common:objectNameList')
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id = h5.id)
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist pfc ON (pfc.id = c.id AND pfc.pos = 0)
-LEFT OUTER JOIN hierarchy h3 ON (c.id = h3.parentid AND h3.pos = 0 AND h3.name = 'collectionobjects_common:assocPeopleGroupList')
-LEFT OUTER JOIN assocpeoplegroup apg ON (apg.id = h3.id)
-LEFT OUTER JOIN collectionobjects_pahma_pahmaethnographicfilecodelist pef ON (pef.id = c.id AND pef.pos = 0)
-JOIN misc ms ON (c.id = ms.id AND ms.lifecyclestate <> 'deleted')
-WHERE REPLACE(GETDISPL(c.computedcurrentlocation), ' ', '0') >= REPLACE($P{startLocDispl}, ' ', '0')
-  AND REPLACE(GETDISPL(c.computedcurrentlocation), ' ', '0') <= REPLACE($P{endLocDispl}, ' ', '0')
-ORDER BY locationKey, sortableObjectNumber, objectName desc]]>
+	COALESCE(GETDISPL(cc.computedcurrentlocation) || ' ' || GETDISPL(ca.computedcrate),
+		GETDISPL(cc.computedcurrentlocation)) AS storageLocation,
+	COALESCE(REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0') || '0'|| REPLACE(GETDISPL(ca.computedcrate), ' ', '0'),
+		REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0')) AS locationKey,
+	cc.objectnumber AS objectNumber,
+	cp.sortableobjectnumber AS sortableObjectNumber,
+	ocg.objectCount AS objectCount,
+	ong.objectName AS objectName,
+	GETDISPL(pfc.item) AS fieldCollectionPlace,
+	GETDISPL(apg.assocpeople) AS culturalGroup,
+	GETDISPL(pef.item) AS ethnographicFileCode
+FROM collectionobjects_common cc
+LEFT OUTER JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+LEFT OUTER JOIN collectionobjects_anthropology ca ON (cc.id = ca.id)
+LEFT OUTER JOIN hierarchy hong ON (cc.id = hong.parentid
+	AND hong.primarytype = 'objectNameGroup'
+	AND hong.pos = 0)
+LEFT OUTER JOIN objectnamegroup ong ON (hong.id = ong.id)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist pfc ON (pfc.id = cc.id
+	AND pfc.pos = 0)
+LEFT OUTER JOIN hierarchy hapg ON (cc.id = hapg.parentid
+	AND hapg.primarytype = 'assocPeopleGroup'
+	AND hapg.pos = 0)
+LEFT OUTER JOIN assocpeoplegroup apg ON (hapg.id = apg.id)
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup')
+	AND hocg.pos = 0
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_pahma_pahmaethnographicfilecodelist pef ON (pef.id = cc.id
+	AND pef.pos = 0)
+JOIN misc m ON (cc.id = m.id
+	AND m.lifecyclestate <> 'deleted')
+WHERE REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0') >= REPLACE($P{startLocDispl}, ' ', '0')
+	AND REPLACE(GETDISPL(cc.computedcurrentlocation), ' ', '0') <= REPLACE($P{endLocDispl}, ' ', '0')
+ORDER BY locationKey, sortableObjectNumber, objectName DESC]]>
 	</queryString>
 	<field name="storageLocation" class="java.lang.String"/>
 	<field name="locationKey" class="java.lang.String"/>

--- a/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/pahmaGroupNAGPRAexcel.jrxml
+++ b/services/report/3rdparty/jasper-cs-report/src/main/resources/tenants/pahma/pahmaGroupNAGPRAexcel.jrxml
@@ -30,198 +30,261 @@
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
 
-        <parameter name="csid" class="java.lang.String" isForPrompting="false">
-                <parameterDescription><![CDATA[Object CSID]]></parameterDescription>
-        </parameter>
-        <parameter name="groupcsid" class="java.lang.String" isForPrompting="false">
-                <parameterDescription><![CDATA[Group CSID]]></parameterDescription>
-        </parameter>
-        <parameter name="csidlist" class="java.lang.String" isForPrompting="false">
-                <parameterDescription><![CDATA[CSID List]]></parameterDescription>
-        </parameter>
-        <parameter name="objcsids" class="java.lang.String" isForPrompting="false">
-                <defaultValueExpression><![CDATA[$P{csidlist} != null ? ("'" + $P{csidlist}.replaceAll(",", "','") + "'") : ""]]></defaultValueExpression>
-        </parameter>
-        <parameter name="wherecsid" class="java.lang.String" isForPrompting="false">
-                <defaultValueExpression><![CDATA[$P{csid} != null ? ("h.name = '" + $P{csid} + "'") : ""]]></defaultValueExpression>
-        </parameter>
-        <parameter name="wheregroup" class="java.lang.String" isForPrompting="false">
-                <defaultValueExpression><![CDATA[$P{groupcsid} != null ? ("h.name IN (SELECT objectcsid FROM relations_common WHERE objectdocumenttype = 'CollectionObject' AND subjectcsid = '" + $P{groupcsid} + "')") : ""]]></defaultValueExpression>
-        </parameter>
-        <parameter name="wherelist" class="java.lang.String" isForPrompting="false">
-                <defaultValueExpression><![CDATA[$P{csidlist} != null ? ("h.name IN (" + $P{objcsids} + ")") : ""]]></defaultValueExpression>
-        </parameter>
-        <parameter name="whereclause" class="java.lang.String" isForPrompting="false">
-                <defaultValueExpression><![CDATA[$P{wherecsid} + $P{wheregroup} + $P{wherelist}]]></defaultValueExpression>
-        </parameter>
+	<parameter name="csid" class="java.lang.String" isForPrompting="false">
+		<parameterDescription><![CDATA[Object CSID]]></parameterDescription>
+	</parameter>
+	<parameter name="groupcsid" class="java.lang.String" isForPrompting="false">
+		<parameterDescription><![CDATA[Group CSID]]></parameterDescription>
+	</parameter>
+	<parameter name="csidlist" class="java.lang.String" isForPrompting="false">
+		<parameterDescription><![CDATA[CSID List]]></parameterDescription>
+	</parameter>
+	<parameter name="objcsids" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{csidlist} != null ? ("'" + $P{csidlist}.replaceAll(",", "','") + "'") : ""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="wherecsid" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{csid} != null ? ("h.name = '" + $P{csid} + "'") : ""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="wheregroup" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{groupcsid} != null ? ("h.name IN (SELECT objectcsid FROM relations_common WHERE objectdocumenttype = 'CollectionObject' AND subjectcsid = '" + $P{groupcsid} + "')") : ""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="wherelist" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{csidlist} != null ? ("h.name IN (" + $P{objcsids} + ")") : ""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="whereclause" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{wherecsid} + $P{wheregroup} + $P{wherelist}]]></defaultValueExpression>
+	</parameter>
 
 	<queryString>
-		<![CDATA[SELECT cc.objectnumber AS "Museum_number",
-COALESCE(STRING_AGG(DISTINCT ang.pahmaaltnum,'␥'),'') AS "Alternate_numbers",
-COALESCE(STRING_AGG(DISTINCT oe.exitnumber,'␥'),'') AS "Exit_numbers",
-COALESCE(STRING_AGG(DISTINCT oe.exitdate,'␥'),'') AS "Exit_dates",
-COALESCE(STRING_AGG(DISTINCT getdispl(oe.newowner),'␥'),'') AS "Current_or_new_owners",
-COALESCE(STRING_AGG(DISTINCT getdispl(oe.exitreason),'␥'),'') AS "Exit_reasons",
-COALESCE(REGEXP_REPLACE(ong.objectname, E'[\\n\\r]+', '¶', 'g' ),'') AS "Object_name",
-COALESCE(REGEXP_REPLACE(bd.item, E'[\\n\\r]+', '¶', 'g' ),'') AS "Description",
-cc.numberofobjects AS "Count",
-COALESCE(getdispl(fcp.item),'') AS "Field_collection_place",
-COALESCE(utils.placename_hierarchy.place_hierarchy,'') AS "Field_collection_place_hierarchy",
-COALESCE(REGEXP_REPLACE(cp.pahmafieldlocverbatim, E'[\\n\\r]+', '¶', 'g' ),'') AS "Verbatim_field_collection_place",
-COALESCE(STRING_AGG(DISTINCT getdispl(fcmeth.item),'␥'),'') AS "Field_collection_methods",
-COALESCE(STRING_AGG(DISTINCT getdispl(fcsrc.item),'␥'),'') AS "Field_collection_sources",
-COALESCE(STRING_AGG(DISTINCT getdispl(fcoll.item),'␥'),'') AS "Field_collectors",
-COALESCE(scd.datedisplaydate,'') AS "Field_collection_date",
-COALESCE(REGEXP_REPLACE(cc.fieldcollectionnote, E'[\\n\\r]+', '¶', 'g' ),'') AS "Field_collection_note",
-COALESCE(getdispl(cp.pahmatmslegacydepartment),'') AS "Legacy_department",
-COALESCE(STRING_AGG(DISTINCT getdispl(nc.item),'␥'),'') AS "Museums_NAGPRA_category_determinations",
-COALESCE(STRING_AGG(DISTINCT getdispl(inv.item),'␥'),'') AS "NAGPRA_inventory",
-COALESCE(STRING_AGG(DISTINCT acc.accnumber,'␥'),'') AS "Accession_numbers",
-COALESCE(STRING_AGG(DISTINCT acc.accdate, '␥'),'') AS "Accession_dates",
-COALESCE(STRING_AGG(DISTINCT acc.acqdate, '␥'),'') AS "Acquisition_dates",
-COALESCE(STRING_AGG(DISTINCT acc.donor,'␥'),'') AS "Donors",
-COALESCE(STRING_AGG(DISTINCT acc.sources,'␥'),'') AS "Acquisition_sources",
-COALESCE(STRING_AGG(DISTINCT acc.methods,'␥'),'') AS "Acquisition_methods",
-COALESCE(STRING_AGG(DISTINCT getdispl(oslAFIL.item),'␥'),'') AS "Affiliation_status_from_object_status",
-COALESCE(STRING_AGG(DISTINCT getdispl(oslDISP.item),'␥'),'') AS "Accession_status_from_object_status",
-COALESCE(STRING_AGG(DISTINCT getdispl(oslMODE.item),'␥'),'') AS "Deaccession_mode_from_object_status",
-COALESCE(STRING_AGG(DISTINCT getdispl(mat.material),'␥'),'') AS "Materials",
-COALESCE(ug.usage,'') AS "Context_of_use",
-COALESCE(STRING_AGG(DISTINCT getdispl(apg.assocpeople),'␥'),'') AS "Cultural_groups",
-COALESCE(spd.datedisplaydate,'') AS "Production_date",
-COALESCE(STRING_AGG(DISTINCT getdispl(prodpl.prodplaces),'␥'),'') AS "Production_places",
-COALESCE(STRING_AGG(DISTINCT prodpl.prodplacehier,'␥'),'') AS "Production_place_hierarchy",
-COALESCE(STRING_AGG(DISTINCT getdispl(oppr.objectproductionpeople),'␥'),'') AS "Production_cultural_groups",
-COALESCE(STRING_AGG(DISTINCT getdispl(oprs.objectproductionperson),'␥'),'') AS "Production_persons",
-COALESCE(STRING_AGG(DISTINCT getdispl(oporg.objectproductionorganization),'␥'),'') AS "Production_organizations",
-COALESCE(STRING_AGG(DISTINCT coll.item,'␥'),'') AS "Collections",
-(SELECT         SUM(va.valueamount) AS "Amount"
-                FROM relations_common rcv
-                JOIN hierarchy hv ON (hv.name=rcv.objectcsid)
-                JOIN valuationcontrols_common vc ON (hv.id=vc.id)
-                JOIN misc mv ON (vc.id=mv.id AND mv.lifecyclestate<>'deleted')
-                LEFT OUTER JOIN hierarchy h4 ON (h4.parentid=vc.id AND h4.name='valuationcontrols_common:valueAmountsList')
-                LEFT OUTER JOIN valueamounts va ON h4.id=va.id
-                WHERE rcv.objectdocumenttype='Valuationcontrol' AND rcv.subjectcsid=h.name
-                GROUP BY rcv.subjectcsid, vc.valuationcontrolrefnumber
-                ORDER BY vc.valuationcontrolrefnumber DESC
-                LIMIT 1
-                ) AS "Valuation",
-COALESCE(STRING_AGG(DISTINCT getdispl(efc.item),'␥'),'') AS "File_codes",
-COALESCE(getdispl(cc.computedcurrentlocation),'') AS "Current_location",
-COALESCE(cp.iscomponent,'') AS "Is_component"
-
+		<![CDATA[SELECT
+	cc.objectnumber AS "Museum_number",
+	COALESCE(STRING_AGG(DISTINCT ang.pahmaaltnum,'␥'),'') AS "Alternate_numbers",
+	COALESCE(STRING_AGG(DISTINCT oe.exitnumber,'␥'),'') AS "Exit_numbers",
+	COALESCE(STRING_AGG(DISTINCT oe.exitdate,'␥'),'') AS "Exit_dates",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(oe.newowner),'␥'),'') AS "Current_or_new_owners",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(oe.exitreason),'␥'),'') AS "Exit_reasons",
+	COALESCE(REGEXP_REPLACE(ong.objectname, E'[\\n\\r]+', '¶', 'g' ),'') AS "Object_name",
+	COALESCE(REGEXP_REPLACE(bd.item, E'[\\n\\r]+', '¶', 'g' ),'') AS "Description",
+	ocg.objectcount AS "Count",
+	COALESCE(GETDISPL(fcp.item),'') AS "Field_collection_place",
+	COALESCE(utils.placename_hierarchy.place_hierarchy,'') AS "Field_collection_place_hierarchy",
+	COALESCE(REGEXP_REPLACE(cp.pahmafieldlocverbatim, E'[\\n\\r]+', '¶', 'g' ),'') AS "Verbatim_field_collection_place",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(fcmeth.item),'␥'),'') AS "Field_collection_methods",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(fcsrc.item),'␥'),'') AS "Field_collection_sources",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(fcoll.item),'␥'),'') AS "Field_collectors",
+	COALESCE(scd.datedisplaydate,'') AS "Field_collection_date",
+	COALESCE(REGEXP_REPLACE(cc.fieldcollectionnote, E'[\\n\\r]+', '¶', 'g' ),'') AS "Field_collection_note",
+	COALESCE(GETDISPL(cp.pahmatmslegacydepartment),'') AS "Legacy_department",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(nc.item),'␥'),'') AS "Museums_NAGPRA_category_determinations",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(inv.item),'␥'),'') AS "NAGPRA_inventory",
+	COALESCE(STRING_AGG(DISTINCT acc.accnumber,'␥'),'') AS "Accession_numbers",
+	COALESCE(STRING_AGG(DISTINCT acc.accdate, '␥'),'') AS "Accession_dates",
+	COALESCE(STRING_AGG(DISTINCT acc.acqdate, '␥'),'') AS "Acquisition_dates",
+	COALESCE(STRING_AGG(DISTINCT acc.donor,'␥'),'') AS "Donors",
+	COALESCE(STRING_AGG(DISTINCT acc.sources,'␥'),'') AS "Acquisition_sources",
+	COALESCE(STRING_AGG(DISTINCT acc.methods,'␥'),'') AS "Acquisition_methods",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(oslAFIL.item),'␥'),'') AS "Affiliation_status_from_object_status",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(oslDISP.item),'␥'),'') AS "Accession_status_from_object_status",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(oslMODE.item),'␥'),'') AS "Deaccession_mode_from_object_status",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(mat.material),'␥'),'') AS "Materials",
+	COALESCE(ug.usage,'') AS "Context_of_use",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(apg.assocpeople),'␥'),'') AS "Cultural_groups",
+	COALESCE(spd.datedisplaydate,'') AS "Production_date",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(prodpl.prodplaces),'␥'),'') AS "Production_places",
+	COALESCE(STRING_AGG(DISTINCT prodpl.prodplacehier,'␥'),'') AS "Production_place_hierarchy",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(oppr.objectproductionpeople),'␥'),'') AS "Production_cultural_groups",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(oprs.objectproductionperson),'␥'),'') AS "Production_persons",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(oporg.objectproductionorganization),'␥'),'') AS "Production_organizations",
+	COALESCE(STRING_AGG(DISTINCT coll.item,'␥'),'') AS "Collections",
+	(SELECT SUM(va.valueamount) AS "Amount"
+		FROM relations_common rcv
+		JOIN hierarchy hv ON (hv.name = rcv.objectcsid)
+		JOIN valuationcontrols_common vc ON (hv.id = vc.id)
+		JOIN misc mv ON (vc.id = mv.id
+			AND mv.lifecyclestate<>'deleted')
+		LEFT OUTER JOIN hierarchy h4 ON (h4.parentid = vc.id
+			AND h4.name = 'valuationcontrols_common:valueAmountsList')
+		LEFT OUTER JOIN valueamounts va ON h4.id = va.id
+		WHERE rcv.objectdocumenttype = 'Valuationcontrol'
+		AND rcv.subjectcsid = h.name
+		GROUP BY
+			rcv.subjectcsid,
+			vc.valuationcontrolrefnumber
+		ORDER BY vc.valuationcontrolrefnumber DESC
+		LIMIT 1
+	) AS "Valuation",
+	COALESCE(STRING_AGG(DISTINCT GETDISPL(efc.item),'␥'),'') AS "File_codes",
+	COALESCE(GETDISPL(cc.computedcurrentlocation),'') AS "Current_location",
+	COALESCE(cp.iscomponent,'') AS "Is_component"
 FROM collectionobjects_common cc
-JOIN collectionobjects_pahma cp ON (cc.id=cp.id)
-JOIN misc m ON (cc.id=m.id AND m.lifecyclestate<>'deleted')
-JOIN hierarchy h ON (cc.id=h.id)
-LEFT OUTER JOIN hierarchy hn ON (cc.id=hn.parentid AND hn.name='collectionobjects_common:objectNameList' AND (hn.pos=0))
-LEFT OUTER JOIN objectnamegroup ong ON (ong.id=hn.id)
-LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id=cc.id AND (bd.pos=0))
-LEFT OUTER JOIN collectionobjects_nagpra_nagpracategories nc ON (nc.id=cc.id)
-LEFT OUTER JOIN collectionobjects_nagpra_nagprainventorynames inv ON (inv.id=cc.id)
-LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (fcp.id=cc.id AND (fcp.pos=0 OR fcp.pos IS NULL))
-LEFT OUTER JOIN places_common pcfcp ON (pcfcp.shortidentifier=REGEXP_REPLACE(fcp.item, '^.*item:name\((.*?)\)''.*', '\1'))
-LEFT OUTER JOIN hierarchy pcsidfcp ON (pcfcp.id=pcsidfcp.id)
-LEFT OUTER JOIN utils.placename_hierarchy ON (pcsidfcp.name=utils.placename_hierarchy.placecsid)
-LEFT OUTER JOIN collectionobjects_pahma_pahmacollectionlist coll ON (coll.id=cc.id)
-LEFT OUTER JOIN collectionobjects_common_fieldcollectionmethods fcmeth ON (fcmeth.id=cc.id)
-LEFT OUTER JOIN collectionobjects_common_fieldcollectionsources fcsrc ON (fcsrc.id=cc.id)
-LEFT OUTER JOIN collectionobjects_common_fieldcollectors fcoll ON (fcoll.id=cc.id)
-LEFT OUTER JOIN hierarchy hcd ON (hcd.parentid=cc.id AND hcd.primarytype='structuredDateGroup' AND hcd.name='collectionobjects_pahma:pahmaFieldCollectionDateGroupList' AND (hcd.pos=0 or hcd.pos IS NULL))
-LEFT OUTER JOIN structureddategroup scd ON (scd.id=hcd.id)
-LEFT OUTER JOIN hierarchy hppr ON (hppr.parentid=cc.id AND hppr.primarytype='objectProductionPeopleGroup')
-LEFT OUTER JOIN objectproductionpeoplegroup oppr ON (oppr.id=hppr.id)
-LEFT OUTER JOIN hierarchy hprs ON (hprs.parentid=cc.id AND hprs.primarytype='objectProductionPersonGroup')
-LEFT OUTER JOIN objectproductionpersongroup oprs ON (oprs.id=hprs.id)
-LEFT OUTER JOIN hierarchy hporg ON (hporg.parentid=cc.id AND hporg.primarytype='objectProductionOrganizationGroup')
-LEFT OUTER JOIN objectproductionorganizationgroup oporg ON (oporg.id=hporg.id)
-LEFT OUTER JOIN collectionobjects_pahma_pahmaethnographicfilecodelist efc ON (efc.id=cc.id)
-LEFT OUTER JOIN hierarchy hm ON (hm.parentid=cc.id AND hm.primarytype='materialGroup')
-LEFT OUTER JOIN materialgroup mat ON (mat.id=hm.id)
-LEFT OUTER JOIN hierarchy hu ON (hu.parentid=cc.id AND hu.primarytype='usageGroup' AND (hu.pos=0 OR hu.pos IS NULL))
-LEFT OUTER JOIN usagegroup ug ON (ug.id=hu.id)
-LEFT OUTER JOIN hierarchy hc ON (hc.parentid=cc.id AND hc.primarytype='assocPeopleGroup')
-LEFT OUTER JOIN assocpeoplegroup apg ON (apg.id=hc.id)
-LEFT OUTER JOIN hierarchy han ON (han.parentid=cc.id AND han.primarytype='pahmaAltNumGroup')
-LEFT OUTER JOIN pahmaaltnumgroup ang ON (ang.id=han.id)
-LEFT OUTER JOIN hierarchy hpd ON (hpd.parentid=cc.id AND hpd.primarytype='structuredDateGroup' AND hpd.name='collectionobjects_common:objectProductionDateGroupList' AND (hpd.pos=0 or hpd.pos IS NULL))
-LEFT OUTER JOIN structureddategroup spd ON (spd.id=hpd.id)
-LEFT OUTER JOIN collectionobjects_pahma_pahmaobjectstatuslist oslAFIL ON (oslAFIL.id=cc.id AND getdispl(oslAFIL.item) IN (
-'culturally affiliated',
-'culturally unaffiliated'))
-LEFT OUTER JOIN collectionobjects_pahma_pahmaobjectstatuslist oslDISP ON (oslDISP.id=cc.id AND getdispl(oslDISP.item) IN (
-'deaccessioned',
-'accessioned',
-'(unknown)',
-'partially deaccessioned',
-'recataloged',
-'partially recataloged'))
-LEFT OUTER JOIN collectionobjects_pahma_pahmaobjectstatuslist oslMODE ON (oslMODE.id=cc.id AND getdispl(oslMODE.item) IN (
-'intended for repatriation',
-'pending repatriation',
-'intended for transfer',
-'repatriated',
-'destroyed',
-'missing',
-'sold',
-'stolen',
-'missing in inventory',
-'discarded',
-'exchanged',
-'partially exchanged',
-'transferred'))
-LEFT OUTER JOIN (SELECT
-                STRING_AGG(DISTINCT xc.exitnumber,'␥') AS "exitnumber",
-                STRING_AGG(DISTINCT sdg.datedisplaydate,'␥') AS "exitdate",
-                STRING_AGG(DISTINCT getdispl(xan.item),'␥') AS "newowner",
-                STRING_AGG(DISTINCT getdispl(xc.exitreason),'␥') AS "exitreason",
-                rcx.subjectcsid
-                FROM relations_common rcx
-                JOIN hierarchy hx ON (hx.name=rcx.objectcsid)
-                JOIN objectexit_common xc ON (hx.id=xc.id)
-                JOIN misc mx ON (xc.id=mx.id AND mx.lifecyclestate<>'deleted')
-                LEFT OUTER JOIN hierarchy h3 ON (h3.parentid=xc.id AND h3.name='objectexit_common:exitDateGroup')
-                LEFT OUTER JOIN structureddategroup sdg ON (h3.id=sdg.id)
-                LEFT OUTER JOIN objectexit_anthropology_newownerlist xan ON (xan.id=xc.id)
-                WHERE rcx.objectdocumenttype='ObjectExit'
-                GROUP BY rcx.subjectcsid) oe ON oe.subjectcsid=h.name
-LEFT OUTER JOIN (SELECT
-                STRING_AGG(DISTINCT ac.acquisitionreferencenumber,'␥') AS "accnumber",
-                STRING_AGG(DISTINCT sad1.datedisplaydate, '␥') AS "accdate",
-                STRING_AGG(DISTINCT sad2.datedisplaydate, '␥') AS "acqdate",
-                STRING_AGG(DISTINCT getdispl(adg.donor),'␥') AS "donor",
-                STRING_AGG(DISTINCT getdispl(acs.item),'␥') AS "sources",
-                STRING_AGG(DISTINCT getdispl(ac.acquisitionmethod),'␥') AS "methods",
-                rcac.subjectcsid
-                FROM relations_common rcac
-                JOIN hierarchy hac ON (rcac.objectcsid=hac.name)
-                JOIN acquisitions_common ac ON (hac.id=ac.id)
-                JOIN misc mac ON (ac.id=mac.id AND mac.lifecyclestate<>'deleted')
-                LEFT OUTER JOIN hierarchy had1 ON (ac.id=had1.parentid AND had1.primarytype='structuredDateGroup' AND had1.name='acquisitions_common:accessionDateGroup' AND (had1.pos=0 OR had1.pos IS NULL))
-                LEFT OUTER JOIN structureddategroup sad1 ON (sad1.id=had1.id)
-                LEFT OUTER JOIN hierarchy had2 ON (ac.id=had2.parentid AND had2.primarytype='structuredDateGroup' AND had2.name='acquisitions_common:acquisitionDateGroupList' AND (had2.pos=0 OR had2.pos IS NULL))
-                LEFT OUTER JOIN structureddategroup sad2 ON (sad2.id=had2.id)
-                LEFT OUTER JOIN hierarchy h2 ON (ac.id = h2.parentid AND h2.name = 'acquisitions_pahma:acquisitionDonorGroupList')
-                LEFT OUTER JOIN acquisitiondonorgroup adg ON (adg.id = h2.id)
-                LEFT OUTER JOIN acquisitions_common_acquisitionsources acs ON (acs.id=ac.id)
-                WHERE rcac.objectdocumenttype='Acquisition'
-                GROUP BY rcac.subjectcsid) acc ON acc.subjectcsid=h.name
-LEFT OUTER JOIN (SELECT
-                STRING_AGG(DISTINCT getdispl(oppl.objectproductionplace),'␥') AS "prodplaces",
-                STRING_AGG(DISTINCT utils.placename_hierarchy.place_hierarchy,'␥') AS "prodplacehier",
-                ccppl.id AS "ccid"
-                FROM collectionobjects_common ccppl
-                LEFT OUTER JOIN hierarchy hppl ON (hppl.parentid=ccppl.id AND hppl.primarytype='objectProductionPlaceGroup')
-                LEFT OUTER JOIN objectproductionplacegroup oppl ON (oppl.id=hppl.id)
-                LEFT OUTER JOIN places_common pcopp ON (pcopp.shortidentifier=REGEXP_REPLACE(oppl.objectproductionplace, '^.*item:name\((.*?)\)''.*', '\1'))
-                LEFT OUTER JOIN hierarchy pcsidopp ON (pcopp.id=pcsidopp.id)
-                LEFT OUTER JOIN utils.placename_hierarchy ON (pcsidopp.name=utils.placename_hierarchy.placecsid)
-                GROUP BY ccppl.id) prodpl ON prodpl.ccid=cc.id
+JOIN collectionobjects_pahma cp ON (cc.id = cp.id)
+JOIN misc m ON (cc.id = m.id
+	AND m.lifecyclestate<>'deleted')
+JOIN hierarchy h ON (cc.id = h.id)
+LEFT OUTER JOIN hierarchy hn ON (cc.id = hn.parentid
+	AND hn.primarytype = 'objectNameGroup'
+	AND (hn.pos = 0))
+LEFT OUTER JOIN objectnamegroup ong ON (ong.id = hn.id)
+LEFT OUTER JOIN collectionobjects_common_briefdescriptions bd ON (bd.id = cc.id
+	AND (bd.pos = 0))
+LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid
+	AND hocg.primarytype = 'objectCountGroup'
+	AND hocg.pos = 0)
+LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+LEFT OUTER JOIN collectionobjects_nagpra_nagpracategories nc ON (nc.id = cc.id)
+LEFT OUTER JOIN collectionobjects_nagpra_nagprainventorynames inv ON (inv.id = cc.id)
+LEFT OUTER JOIN collectionobjects_pahma_pahmafieldcollectionplacelist fcp ON (fcp.id = cc.id
+	AND (fcp.pos = 0 OR fcp.pos IS NULL))
+LEFT OUTER JOIN places_common pcfcp ON (pcfcp.shortidentifier = REGEXP_REPLACE(fcp.item, '^.*item:name\((.*?)\)''.*', '\1'))
+LEFT OUTER JOIN hierarchy pcsidfcp ON (pcfcp.id = pcsidfcp.id)
+LEFT OUTER JOIN utils.placename_hierarchy ON (pcsidfcp.name = utils.placename_hierarchy.placecsid)
+LEFT OUTER JOIN collectionobjects_pahma_pahmacollectionlist coll ON (coll.id = cc.id)
+LEFT OUTER JOIN collectionobjects_common_fieldcollectionmethods fcmeth ON (fcmeth.id = cc.id)
+LEFT OUTER JOIN collectionobjects_common_fieldcollectionsources fcsrc ON (fcsrc.id = cc.id)
+LEFT OUTER JOIN collectionobjects_common_fieldcollectors fcoll ON (fcoll.id = cc.id)
+LEFT OUTER JOIN hierarchy hcd ON (hcd.parentid = cc.id
+	AND hcd.primarytype = 'structuredDateGroup'
+	AND hcd.name = 'collectionobjects_pahma:pahmaFieldCollectionDateGroupList'
+	AND (hcd.pos = 0 OR hcd.pos IS NULL))
+LEFT OUTER JOIN structureddategroup scd ON (scd.id = hcd.id)
+LEFT OUTER JOIN hierarchy hppr ON (hppr.parentid = cc.id
+	AND hppr.primarytype = 'objectProductionPeopleGroup')
+LEFT OUTER JOIN objectproductionpeoplegroup oppr ON (oppr.id = hppr.id)
+LEFT OUTER JOIN hierarchy hprs ON (hprs.parentid = cc.id
+	AND hprs.primarytype = 'objectProductionPersonGroup')
+LEFT OUTER JOIN objectproductionpersongroup oprs ON (oprs.id = hprs.id)
+LEFT OUTER JOIN hierarchy hporg ON (hporg.parentid = cc.id
+	AND hporg.primarytype = 'objectProductionOrganizationGroup')
+LEFT OUTER JOIN objectproductionorganizationgroup oporg ON (oporg.id = hporg.id)
+LEFT OUTER JOIN collectionobjects_pahma_pahmaethnographicfilecodelist efc ON (efc.id = cc.id)
+LEFT OUTER JOIN hierarchy hm ON (hm.parentid = cc.id
+	AND hm.primarytype = 'materialGroup')
+LEFT OUTER JOIN materialgroup mat ON (mat.id = hm.id)
+LEFT OUTER JOIN hierarchy hu ON (hu.parentid = cc.id
+	AND hu.primarytype = 'usageGroup'
+	AND (hu.pos = 0 OR hu.pos IS NULL))
+LEFT OUTER JOIN usagegroup ug ON (ug.id = hu.id)
+LEFT OUTER JOIN hierarchy hc ON (hc.parentid = cc.id
+	AND hc.primarytype = 'assocPeopleGroup')
+LEFT OUTER JOIN assocpeoplegroup apg ON (apg.id = hc.id)
+LEFT OUTER JOIN hierarchy han ON (han.parentid = cc.id
+	AND han.primarytype = 'pahmaAltNumGroup')
+LEFT OUTER JOIN pahmaaltnumgroup ang ON (ang.id = han.id)
+LEFT OUTER JOIN hierarchy hpd ON (hpd.parentid = cc.id
+	AND hpd.primarytype = 'structuredDateGroup'
+	AND hpd.name = 'collectionobjects_common:objectProductionDateGroupList'
+	AND (hpd.pos = 0 OR hpd.pos IS NULL))
+LEFT OUTER JOIN structureddategroup spd ON (spd.id = hpd.id)
+LEFT OUTER JOIN collectionobjects_pahma_pahmaobjectstatuslist oslAFIL
+	ON (oslAFIL.id = cc.id
+	AND GETDISPL(oslAFIL.item) IN (
+		'culturally affiliated',
+		'culturally unaffiliated'))
+LEFT OUTER JOIN collectionobjects_pahma_pahmaobjectstatuslist oslDISP
+	ON (oslDISP.id = cc.id
+	AND GETDISPL(oslDISP.item) IN (
+		'deaccessioned',
+		'accessioned',
+		'(unknown)',
+		'partially deaccessioned',
+		'recataloged',
+		'partially recataloged'))
+LEFT OUTER JOIN collectionobjects_pahma_pahmaobjectstatuslist oslMODE ON (oslMODE.id = cc.id
+	AND GETDISPL(oslMODE.item) IN (
+		'intended for repatriation',
+		'pending repatriation',
+		'intended for transfer',
+		'repatriated',
+		'destroyed',
+		'missing',
+		'sold',
+		'stolen',
+		'missing in inventory',
+		'discarded',
+		'exchanged',
+		'partially exchanged',
+		'transferred'))
+LEFT OUTER JOIN (
+	SELECT
+		STRING_AGG(DISTINCT xc.exitnumber,'␥') AS "exitnumber",
+		STRING_AGG(DISTINCT sdg.datedisplaydate,'␥') AS "exitdate",
+		STRING_AGG(DISTINCT GETDISPL(xan.item),'␥') AS "newowner",
+		STRING_AGG(DISTINCT GETDISPL(xc.exitreason),'␥') AS "exitreason",
+		rcx.subjectcsid
+	FROM relations_common rcx
+	JOIN hierarchy hx ON (hx.name = rcx.objectcsid)
+	JOIN objectexit_common xc ON (hx.id = xc.id)
+	JOIN misc mx ON (xc.id = mx.id
+		AND mx.lifecyclestate<>'deleted')
+	LEFT OUTER JOIN hierarchy h3 ON (h3.parentid = xc.id
+		AND h3.name = 'objectexit_common:exitDateGroup')
+	LEFT OUTER JOIN structureddategroup sdg ON (h3.id = sdg.id)
+	LEFT OUTER JOIN objectexit_anthropology_newownerlist xan ON (xan.id = xc.id)
+	WHERE rcx.objectdocumenttype = 'ObjectExit'
+	GROUP BY rcx.subjectcsid
+	) oe ON oe.subjectcsid = h.name
+LEFT OUTER JOIN (
+	SELECT
+		STRING_AGG(DISTINCT ac.acquisitionreferencenumber,'␥') AS "accnumber",
+		STRING_AGG(DISTINCT sad1.datedisplaydate, '␥') AS "accdate",
+		STRING_AGG(DISTINCT sad2.datedisplaydate, '␥') AS "acqdate",
+		STRING_AGG(DISTINCT GETDISPL(adg.donor),'␥') AS "donor",
+		STRING_AGG(DISTINCT GETDISPL(acs.item),'␥') AS "sources",
+		STRING_AGG(DISTINCT GETDISPL(ac.acquisitionmethod),'␥') AS "methods",
+		rcac.subjectcsid
+	FROM relations_common rcac
+	JOIN hierarchy hac ON (rcac.objectcsid = hac.name)
+	JOIN acquisitions_common ac ON (hac.id = ac.id)
+	JOIN misc mac ON (ac.id = mac.id
+		AND mac.lifecyclestate<>'deleted')
+	LEFT OUTER JOIN hierarchy had1 ON (ac.id = had1.parentid
+		AND had1.primarytype = 'structuredDateGroup'
+		AND had1.name = 'acquisitions_common:accessionDateGroup'
+		AND (had1.pos = 0 OR had1.pos IS NULL))
+	LEFT OUTER JOIN structureddategroup sad1 ON (sad1.id = had1.id)
+	LEFT OUTER JOIN hierarchy had2 ON (ac.id = had2.parentid
+		AND had2.primarytype = 'structuredDateGroup'
+		AND had2.name = 'acquisitions_common:acquisitionDateGroupList'
+		AND (had2.pos = 0 OR had2.pos IS NULL))
+	LEFT OUTER JOIN structureddategroup sad2 ON (sad2.id = had2.id)
+	LEFT OUTER JOIN hierarchy h2 ON (ac.id = h2.parentid
+		AND h2.name = 'acquisitions_pahma:acquisitionDonorGroupList')
+	LEFT OUTER JOIN acquisitiondonorgroup adg ON (adg.id = h2.id)
+	LEFT OUTER JOIN acquisitions_common_acquisitionsources acs ON (acs.id = ac.id)
+	WHERE rcac.objectdocumenttype = 'Acquisition'
+	GROUP BY rcac.subjectcsid
+	) acc ON acc.subjectcsid = h.name
+LEFT OUTER JOIN (
+	SELECT
+		STRING_AGG(DISTINCT GETDISPL(oppl.objectproductionplace),'␥') AS "prodplaces",
+		STRING_AGG(DISTINCT utils.placename_hierarchy.place_hierarchy,'␥') AS "prodplacehier",
+		ccppl.id AS "ccid"
+	FROM collectionobjects_common ccppl
+	LEFT OUTER JOIN hierarchy hppl ON (hppl.parentid = ccppl.id
+		AND hppl.primarytype = 'objectProductionPlaceGroup')
+	LEFT OUTER JOIN objectproductionplacegroup oppl ON (oppl.id = hppl.id)
+	LEFT OUTER JOIN places_common pcopp ON (pcopp.shortidentifier = REGEXP_REPLACE(oppl.objectproductionplace, '^.*item:name\((.*?)\)''.*', '\1'))
+	LEFT OUTER JOIN hierarchy pcsidopp ON (pcopp.id = pcsidopp.id)
+	LEFT OUTER JOIN utils.placename_hierarchy ON (pcsidopp.name = utils.placename_hierarchy.placecsid)
+	GROUP BY ccppl.id
+	) prodpl ON prodpl.ccid = cc.id
 WHERE $P!{whereclause}
 AND (oe.exitReason NOT LIKE '%recataloged%' OR oe.exitReason IS NULL)
-GROUP BY cc.id, h.name, fcp.item, ong.objectname, bd.item, cp.pahmatmslegacydepartment, cp.sortableobjectnumber,
-ug.usage, cp.iscomponent, cp.pahmafieldlocverbatim, scd.datedisplaydate, spd.datedisplaydate, placename_hierarchy.place_hierarchy
+GROUP BY
+	cc.id,
+	h.name,
+	fcp.item,
+	bd.item,
+	ocg.objectcount,
+	ong.objectname,
+	cp.pahmatmslegacydepartment,
+	cp.sortableobjectnumber,
+	ug.usage,
+	cp.iscomponent,
+	cp.pahmafieldlocverbatim,
+	scd.datedisplaydate,
+	spd.datedisplaydate,
+	placename_hierarchy.place_hierarchy
 ORDER BY cp.sortableobjectnumber]]>
 	</queryString>
 	<field name="Museum_number" class="java.lang.String"/>


### PR DESCRIPTION
changes were merged into ucb_8.0 branch on 8/16/2024, but not into main branch.  Creating new PR to commit changes into main branch.  Only  23/25 reports were updated in this PR vs. PR 424 because:
- ObjectEntry,Wide,Culture removed in CSC-2354
- researcher_summary_w_acc_alt revised in CSC-2363