### PR TITLE
8.3 Updates > new cspace-ui and profile plugin versions

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -27,7 +27,7 @@ cspace.im.root=
 # UI settings
 cspace.ui.package.name=cspace-ui
 cspace.ui.library.name=cspaceUI
-cspace.ui.version=10.0.2-ucb.1
+cspace.ui.version=10.2.0-ucb.1
 cspace.ui.build.branch=master
 cspace.ui.build.node.ver=14
 service.ui.library.name=${cspace.ui.library.name}-service

--- a/cspace-ui/ucbg/build.properties
+++ b/cspace-ui/ucbg/build.properties
@@ -3,4 +3,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-ucbg
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileUCBG
-tenant.ui.profile.plugin.version=4.0.0-rc.2
+tenant.ui.profile.plugin.version=4.1.0

--- a/cspace-ui/ucjeps/build.properties
+++ b/cspace-ui/ucjeps/build.properties
@@ -3,4 +3,4 @@ tenant.ui.basename=/cspace/${tenant.shortname}
 
 tenant.ui.profile.plugin.package.name=cspace-ui-plugin-profile-ucjeps
 tenant.ui.profile.plugin.library.name=cspaceUIPluginProfileUCJEPS
-tenant.ui.profile.plugin.version=4.0.0-rc.2
+tenant.ui.profile.plugin.version=4.1.0


### PR DESCRIPTION
This is a follow-up from: https://github.com/cspace-deployment/services/pull/448. It updates `build.properties` with the new versions of cspace-ui and profile plugins.  
Dependencies: 
https://github.com/cspace-deployment/cspace-ui.js/pull/72
https://github.com/cspace-deployment/cspace-ui-plugin-profile-ucbg.js/pull/83
https://github.com/cspace-deployment/cspace-ui-plugin-profile-ucjeps.js/pull/43

It can be merged once dependencies are merged and new npm versions are published. @lkvoong, please let me know when this is done so that I do a last check if the build runs fine.
