### PR TITLE
DRYD-1898: Procedure > Bot Garden > Modify Current Location

### DIFF
--- a/3rdparty/nuxeo/nuxeo-platform-listener/tenants/botgarden/src/main/java/org/collectionspace/services/listener/botgarden/UpdateLocationListener.java
+++ b/3rdparty/nuxeo/nuxeo-platform-listener/tenants/botgarden/src/main/java/org/collectionspace/services/listener/botgarden/UpdateLocationListener.java
@@ -45,7 +45,10 @@ public class UpdateLocationListener extends AbstractCSEventSyncListenerImpl {
 	 * <ul>
 	 * <li>If the plant is dead, set currentLocation to none</li>
 	 * <li>Set the previousLocation field to the previous value of the currentLocation field</li>
-	 * </ui>
+	 * <li>If the action code is Moved or Planted Out, clear the Garden Coordinate Information
+	 *     (georeference) fields so that the garden location does not become out-of-sync with
+	 *     the lat/longs</li>
+	 * </ul>
 	 */
 	@Override
 	public void handleCSEvent(Event event) {
@@ -76,10 +79,23 @@ public class UpdateLocationListener extends AbstractCSEventSyncListenerImpl {
 				 */
 				ec.setProperty(CreateVersionListener.SKIP_PROPERTY, true);
 			}
+			else if (actionCode != null && isGeoreferenceErasingActionCode(actionCode)) {
+				/*
+				 * If the document is created with an action code of Moved or Planted Out, clear the
+				 * georeference fields. Save the document to persist the cleared values; this also
+				 * causes versioning via documentModified, so skip the documentCreated versioning.
+				 */
+				clearGeoreferenceFields(doc);
+				context.getCoreSession().saveDocument(doc);
+				ec.setProperty(CreateVersionListener.SKIP_PROPERTY, true);
+			}
 		}
 		else {
 			if (actionCode != null && RefNameUtils.doShortIDsMatch(actionCode, MovementBotGardenConstants.DEAD_ACTION_CODE)) {
 				doc.setProperty(MovementConstants.CURRENT_LOCATION_SCHEMA_NAME, MovementConstants.CURRENT_LOCATION_FIELD_NAME, MovementConstants.NONE_LOCATION);
+			}
+			else if (actionCode != null && isGeoreferenceErasingActionCode(actionCode)) {
+				clearGeoreferenceFields(doc);
 			}
 
 			DocumentModel previousDoc = (DocumentModel) context.getProperty(CoreEventConstants.PREVIOUS_DOCUMENT_MODEL);
@@ -89,6 +105,27 @@ public class UpdateLocationListener extends AbstractCSEventSyncListenerImpl {
 
 			doc.setProperty(MovementBotGardenConstants.PREVIOUS_LOCATION_SCHEMA_NAME, MovementBotGardenConstants.PREVIOUS_LOCATION_FIELD_NAME, previousLocation);
 		}
+	}
+
+	private boolean isGeoreferenceErasingActionCode(String actionCode) {
+		return RefNameUtils.doShortIDsMatch(actionCode, MovementBotGardenConstants.MOVED_ACTION_CODE)
+				|| RefNameUtils.doShortIDsMatch(actionCode, MovementBotGardenConstants.PLANTED_OUT_ACTION_CODE);
+	}
+
+	private void clearGeoreferenceFields(DocumentModel doc) {
+		String schema = MovementBotGardenConstants.GEOREFERENCE_SCHEMA_NAME;
+		doc.setProperty(schema, MovementBotGardenConstants.DECIMAL_LATITUDE_FIELD_NAME, null);
+		doc.setProperty(schema, MovementBotGardenConstants.DECIMAL_LONGITUDE_FIELD_NAME, null);
+		doc.setProperty(schema, MovementBotGardenConstants.GEODETIC_DATUM_FIELD_NAME, null);
+		doc.setProperty(schema, MovementBotGardenConstants.COORD_UNCERTAINTY_IN_METERS_FIELD_NAME, null);
+		doc.setProperty(schema, MovementBotGardenConstants.POINT_RADIUS_SPATIAL_FIT_FIELD_NAME, null);
+		doc.setProperty(schema, MovementBotGardenConstants.GEO_REFERENCED_BY_FIELD_NAME, null);
+		doc.setProperty(schema, MovementBotGardenConstants.GEO_REF_DATE_FIELD_NAME, null);
+		doc.setProperty(schema, MovementBotGardenConstants.GEO_REF_PROTOCOL_FIELD_NAME, null);
+		doc.setProperty(schema, MovementBotGardenConstants.GEO_REF_SOURCE_FIELD_NAME, null);
+		doc.setProperty(schema, MovementBotGardenConstants.GEO_REF_VERIFICATION_STATUS_FIELD_NAME, null);
+		doc.setProperty(schema, MovementBotGardenConstants.GEO_REF_REMARKS_FIELD_NAME, null);
+		doc.setProperty(schema, MovementBotGardenConstants.GEO_REF_PLACE_NAME_FIELD_NAME, null);
 	}
 	
 	@Override

--- a/services/movement/service/src/main/java/org/collectionspace/services/movement/nuxeo/MovementBotGardenConstants.java
+++ b/services/movement/service/src/main/java/org/collectionspace/services/movement/nuxeo/MovementBotGardenConstants.java
@@ -24,8 +24,24 @@ public class MovementBotGardenConstants {
 	// See CollectionSpace wiki documentation for "RefName" values
 	// https://collectionspace.atlassian.net/wiki/spaces/DOC/pages/2754224504/RefName
 	public static final String DEAD_ACTION_CODE = "urn:cspace:botgarden.cspace.berkeley.edu:vocabularies:name(actionCode):item:name(actCode00)";
+	public static final String PLANTED_OUT_ACTION_CODE = "urn:cspace:botgarden.cspace.berkeley.edu:vocabularies:name(actionCode):item:name(actCode01)";
+	public static final String MOVED_ACTION_CODE = "urn:cspace:botgarden.cspace.berkeley.edu:vocabularies:name(actionCode):item:name(actCode02)";
 	public static final String REVIVED_ACTION_CODE = "urn:cspace:botgarden.cspace.berkeley.edu:vocabularies:name(actionCode):item:name(actCode06)";
 	public static final String OTHER_ACTION_CODE = "urn:cspace:botgarden.cspace.berkeley.edu:vocabularies:name(actionCode):item:name(actCode05)";
+
+	public static final String GEOREFERENCE_SCHEMA_NAME = BOTGARDEN_SCHEMA_NAME;
+	public static final String DECIMAL_LATITUDE_FIELD_NAME = "decimalLatitude";
+	public static final String DECIMAL_LONGITUDE_FIELD_NAME = "decimalLongitude";
+	public static final String GEODETIC_DATUM_FIELD_NAME = "geodeticDatum";
+	public static final String COORD_UNCERTAINTY_IN_METERS_FIELD_NAME = "coordUncertaintyInMeters";
+	public static final String POINT_RADIUS_SPATIAL_FIT_FIELD_NAME = "pointRadiusSpatialFit";
+	public static final String GEO_REFERENCED_BY_FIELD_NAME = "geoReferencedBy";
+	public static final String GEO_REF_DATE_FIELD_NAME = "geoRefDate";
+	public static final String GEO_REF_PROTOCOL_FIELD_NAME = "geoRefProtocol";
+	public static final String GEO_REF_SOURCE_FIELD_NAME = "geoRefSource";
+	public static final String GEO_REF_VERIFICATION_STATUS_FIELD_NAME = "geoRefVerificationStatus";
+	public static final String GEO_REF_REMARKS_FIELD_NAME = "geoRefRemarks";
+	public static final String GEO_REF_PLACE_NAME_FIELD_NAME = "geoRefPlaceName";
 
 	public static final String LABEL_REQUESTED_SCHEMA_NAME = BOTGARDEN_SCHEMA_NAME;
 	public static final String LABEL_REQUESTED_FIELD_NAME = "labelRequested";


### PR DESCRIPTION
**What does this do?**
* Extends the `UpdateLocationListener` to clear Garden Coordinate Information on Moved and Planted Out actions
* The clearing of the fields is also done on `DOCUMENT_CREATED` event. Similar to the already existing `dead` action code, skipping the `documentCreated` versioning is applied.

**Why are we doing this? (with JIRA link)**
We need to clear the garden coordinate information fields on “Moved“ and “Planted Out“, so that the garden location does not become out-of-sync with the lat/long: https://collectionspace.atlassian.net/browse/DRYD-1898

**How should this be tested? Do these changes have associated tests?**
Please follow the instructions at the: https://github.com/cspace-deployment/cspace-ui-plugin-profile-ucbg.js/pull/85

**Dependencies for merging? Releasing to production?**
It should be merged and releases along these PRs:
https://github.com/cspace-deployment/application/pull/209
https://github.com/cspace-deployment/cspace-ui-plugin-profile-ucbg.js/pull/85

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@spirosdi ran this locally
