### PR TITLE
8.1.1 Patch Release - Disable DTD when parsing XML 

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -9,7 +9,7 @@ host=127.0.0.1
 #
 # Release version info
 #
-release.version=8.1.1
+release.version=8.1.2
 cspace.release=${release.version}
 cspace.instance.id=${env.CSPACE_INSTANCE_ID}
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<name>services</name>
 
 	<properties>
-		<revision>8.1.1</revision>
+		<revision>8.1.2</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<cspace.services.version>${revision}</cspace.services.version>
 		<cspace.services.client.version>${revision}</cspace.services.client.version>

--- a/services/client/src/main/java/org/collectionspace/services/client/PoxPayload.java
+++ b/services/client/src/main/java/org/collectionspace/services/client/PoxPayload.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -15,6 +16,8 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.stream.StreamSource;
 
 import com.sun.xml.bind.api.impl.NameConverter;
@@ -29,8 +32,8 @@ import org.dom4j.Namespace;
 import org.dom4j.io.SAXReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
 
-// TODO: Auto-generated Javadoc
 /**
  * The Class PoxPayload.
  *
@@ -81,8 +84,19 @@ public abstract class PoxPayload<PT extends PayloadPart> {
 		return validRootElementLabels;
 	}
 
-	private void setDomDocument(Document dom) throws DocumentException {
-		this.domDocument = dom;
+	private void setDomDocument(final String xmlPayload) throws DocumentException {
+		SAXReader reader = new SAXReader();
+		try {
+			reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		} catch (SAXException saxException) {
+			final String error = "Unable to disable Doctype features, aborting document read";
+			logger.error(error, saxException);
+			throw new DocumentException(error);
+		}
+
+        this.domDocument = reader.read(new StringReader(xmlPayload));
 		this.parts = null;
 
 		String label = domDocument.getRootElement().getName().toLowerCase();
@@ -141,13 +155,11 @@ public abstract class PoxPayload<PT extends PayloadPart> {
 	 * Instantiates a new PoxPayload by parsing the payload into a DOM4j
 	 * Document instance
 	 *
-	 * @param payloadName the payload name
+	 * @param xmlPayload the payload
 	 */
 	protected PoxPayload(String xmlPayload) throws DocumentException {
 		this.xmlPayload = xmlPayload;
-		SAXReader reader = new SAXReader();
-		Document dom  = reader.read(new StringReader(xmlPayload));
-		setDomDocument(dom);
+		setDomDocument(xmlPayload);
 	}
 
     /**
@@ -158,10 +170,8 @@ public abstract class PoxPayload<PT extends PayloadPart> {
      * @throws IOException Signals that an I/O exception has occurred.
      */
     protected PoxPayload(File file) throws DocumentException, IOException {
-    	this.xmlPayload = FileUtils.readFileToString(file);
-        SAXReader reader = new SAXReader();
-        Document dom = reader.read(file);
-		setDomDocument(dom);
+    	this.xmlPayload = FileUtils.readFileToString(file, Charset.defaultCharset());
+		setDomDocument(xmlPayload);
     }
 
 	/**
@@ -365,7 +375,11 @@ public abstract class PoxPayload<PT extends PayloadPart> {
 		public static Object toObject(Element elementInput) {
 			Object result = null;
 
+
 			try {
+				final XMLInputFactory xmlInputFactory = XMLInputFactory.newFactory();
+				xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+				xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
 				Namespace namespace = elementInput.getNamespace();
 
 				if (StringUtils.isNotEmpty(namespace.getURI())) {
@@ -373,13 +387,12 @@ public abstract class PoxPayload<PT extends PayloadPart> {
 					JAXBContext jc = JAXBContext.newInstance(thePackage);
 					Unmarshaller um = jc.createUnmarshaller();
 
-					result = um.unmarshal(new StreamSource(new StringReader(elementInput.asXML())));
+					XMLStreamReader xmlStream = xmlInputFactory.createXMLStreamReader(
+						new StreamSource(new StringReader(elementInput.asXML())));
+					result = um.unmarshal(xmlStream);
 				}
 			} catch (Exception e) {
-				if (logger.isInfoEnabled()) {
-					String msg = String.format("Could not unmarshal XML element '%s' into a JAXB object.", elementInput.getName());
-					logger.info(msg);
-				}
+				logger.error("Could not unmarshal XML element '{}' into a JAXB object.", elementInput.getName(), e);
 			}
 
 			return result;
@@ -412,9 +425,7 @@ public abstract class PoxPayload<PT extends PayloadPart> {
     		Document doc = DocumentHelper.parseText(text);
     		result = doc.getRootElement(); //FIXME: REM - call .detach() to free the element
     	} catch (Exception e) {
-    		String msg = String.format("Could not marshal JAXB object '%s' to an XML element.",
-    				jaxbObject.toString());
-    		logger.error(msg);
+    		logger.error("Could not marshal JAXB object '{}' to an XML element.", jaxbObject, e);
     	}
 
     	return result;


### PR DESCRIPTION
This is a cherry is a cherry pick of [d223cb8](https://github.com/collectionspace/services/pull/540/commits/d223cb8465126270e8f4b87a9be3e5ac586a2583) that handles the [XML External Entity (XXE) vulnerability ](https://github.com/collectionspace/services/security/advisories/GHSA-hxxq-7jjv-52c4). For further details please check original PR: https://github.com/collectionspace/services/pull/540

It also bumps version to 8.1.2