### PR TITLE
DRYD-2121: Advanced Search > UCBG > Taxonomic name is not displaying in search results

### DIFF
--- a/services/advancedsearch/jaxb/src/main/java/org/collectionspace/services/advancedsearch/model/TaxonModel.java
+++ b/services/advancedsearch/jaxb/src/main/java/org/collectionspace/services/advancedsearch/model/TaxonModel.java
@@ -3,11 +3,11 @@ package org.collectionspace.services.advancedsearch.model;
 import java.util.List;
 
 import org.collectionspace.services.collectionobject.CollectionobjectsCommon;
-import org.collectionspace.services.collectionobject.domain.naturalhistory_extension.CollectionobjectsNaturalhistory;
-import org.collectionspace.services.collectionobject.domain.naturalhistory_extension.DeterminationHistoryGroup;
-import org.collectionspace.services.collectionobject.domain.naturalhistory_extension.DeterminationHistoryGroupList;
-import org.collectionspace.services.collectionobject.domain.naturalhistory_extension.TaxonomicIdentGroup;
-import org.collectionspace.services.collectionobject.domain.naturalhistory_extension.TaxonomicIdentGroupList;
+import org.collectionspace.services.collectionobject.domain.naturalhistory.CollectionobjectsNaturalhistory;
+import org.collectionspace.services.collectionobject.domain.naturalhistory.DeterminationHistoryGroup;
+import org.collectionspace.services.collectionobject.domain.naturalhistory.DeterminationHistoryGroupList;
+import org.collectionspace.services.collectionobject.domain.naturalhistory.TaxonomicIdentGroup;
+import org.collectionspace.services.collectionobject.domain.naturalhistory.TaxonomicIdentGroupList;
 
 public class TaxonModel {
 

--- a/services/advancedsearch/jaxb/src/main/java/org/collectionspace/services/advancedsearch/model/TaxonModel.java
+++ b/services/advancedsearch/jaxb/src/main/java/org/collectionspace/services/advancedsearch/model/TaxonModel.java
@@ -39,7 +39,7 @@ public class TaxonModel {
 
 	public static String determinationTaxon(final CollectionobjectsNaturalhistory naturalHistory) {
 		String taxon = null;
-		if (naturalHistory != null && naturalHistory.getTaxonomicIdentGroupList() != null) {
+		if (naturalHistory != null && naturalHistory.getDeterminationHistoryGroupList() != null) {
 			DeterminationHistoryGroupList determinationGroupList = naturalHistory.getDeterminationHistoryGroupList();
 			List<DeterminationHistoryGroup> determinationGroups = determinationGroupList.getDeterminationHistoryGroup();
 			if (!determinationGroups.isEmpty()) {

--- a/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/AdvancedSearchJAXBContext.java
+++ b/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/AdvancedSearchJAXBContext.java
@@ -6,7 +6,7 @@ import javax.xml.bind.JAXBException;
 import org.collectionspace.collectionspace_core.CollectionSpaceCore;
 import org.collectionspace.services.collectionobject.CollectionobjectsCommon;
 import org.collectionspace.services.collectionobject.domain.nagpra.CollectionObjectsNAGPRA;
-import org.collectionspace.services.collectionobject.domain.naturalhistory_extension.CollectionobjectsNaturalhistory;
+import org.collectionspace.services.collectionobject.domain.naturalhistory.CollectionobjectsNaturalhistory;
 
 /**
  * Singleton for the {@link JAXBContext} which the AdvancedSearch will use

--- a/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/mapper/CollectionObjectMapper.java
+++ b/services/advancedsearch/service/src/main/java/org/collectionspace/services/advancedsearch/mapper/CollectionObjectMapper.java
@@ -2,7 +2,7 @@ package org.collectionspace.services.advancedsearch.mapper;
 
 import static org.collectionspace.services.client.CollectionSpaceClient.COLLECTIONSPACE_CORE_SCHEMA;
 import static org.collectionspace.services.client.CollectionSpaceClient.NAGPRA_EXTENSION_NAME;
-import static org.collectionspace.services.client.CollectionSpaceClient.NATURALHISTORY_EXT_EXTENSION_NAME;
+import static org.collectionspace.services.client.CollectionSpaceClient.NATURALHISTORY_EXTENSION_NAME;
 import static org.collectionspace.services.client.CollectionSpaceClient.PART_COMMON_LABEL;
 import static org.collectionspace.services.client.CollectionSpaceClient.PART_LABEL_SEPARATOR;
 
@@ -29,7 +29,7 @@ import org.collectionspace.services.client.PayloadOutputPart;
 import org.collectionspace.services.client.PoxPayloadOut;
 import org.collectionspace.services.collectionobject.CollectionobjectsCommon;
 import org.collectionspace.services.collectionobject.domain.nagpra.CollectionObjectsNAGPRA;
-import org.collectionspace.services.collectionobject.domain.naturalhistory_extension.CollectionobjectsNaturalhistory;
+import org.collectionspace.services.collectionobject.domain.naturalhistory.CollectionobjectsNaturalhistory;
 import org.collectionspace.services.nuxeo.client.handler.CSDocumentModelList.CSDocumentModelResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +48,7 @@ public class CollectionObjectMapper {
             CollectionObjectClient.SERVICE_NAME + PART_LABEL_SEPARATOR + PART_COMMON_LABEL;
 
     private static final String NATHIST_PART_NAME =
-            CollectionObjectClient.SERVICE_NAME + PART_LABEL_SEPARATOR + NATURALHISTORY_EXT_EXTENSION_NAME;
+            CollectionObjectClient.SERVICE_NAME + PART_LABEL_SEPARATOR + NATURALHISTORY_EXTENSION_NAME;
 
     private static final String NAGPRA_PART_NAME =
             CollectionObjectClient.SERVICE_NAME + PART_LABEL_SEPARATOR + NAGPRA_EXTENSION_NAME;
@@ -64,7 +64,7 @@ public class CollectionObjectMapper {
     /**
      * Map a {@link CSDocumentModelResponse} to a {@link AdvancedsearchListItem}. This looks at the response for each
      * of the collectionspace_core, collectionobjects_common, collectionobjects_nagpra, and
-     * collectionobjects_naturalhistory_extension parts and pulls fields out of each based on the search specification.
+     * collectionobjects_naturalhistory parts and pulls fields out of each based on the search specification.
      * We don't differentiate between profiles here and instead return everything available for the ui.
      * <p>
      * Note that this doesn't handle the {@link AdvancedsearchListItem#setRelated(Boolean)} as that requires access to

--- a/services/collectionobject/client/src/main/java/org/collectionspace/services/client/CollectionObjectFactory.java
+++ b/services/collectionobject/client/src/main/java/org/collectionspace/services/client/CollectionObjectFactory.java
@@ -25,7 +25,7 @@
 package org.collectionspace.services.client;
 
 import org.collectionspace.services.collectionobject.CollectionobjectsCommon;
-import org.collectionspace.services.collectionobject.domain.naturalhistory_extension.CollectionobjectsNaturalhistory;
+import org.collectionspace.services.collectionobject.domain.naturalhistory.CollectionobjectsNaturalhistory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/services/collectionobject/client/src/test/java/org/collectionspace/services/client/test/CollectionObjectServiceTest.java
+++ b/services/collectionobject/client/src/test/java/org/collectionspace/services/client/test/CollectionObjectServiceTest.java
@@ -46,7 +46,7 @@ import org.collectionspace.services.collectionobject.OtherNumber;
 import org.collectionspace.services.collectionobject.ResponsibleDepartmentList;
 import org.collectionspace.services.collectionobject.TitleGroup;
 import org.collectionspace.services.collectionobject.TitleGroupList;
-import org.collectionspace.services.collectionobject.domain.naturalhistory_extension.CollectionobjectsNaturalhistory;
+import org.collectionspace.services.collectionobject.domain.naturalhistory.CollectionobjectsNaturalhistory;
 import org.collectionspace.services.jaxb.AbstractCommonList;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/services/collectionobject/jaxb/src/main/resources/collectionobjects_naturalhistory.xsd
+++ b/services/collectionobject/jaxb/src/main/resources/collectionobjects_naturalhistory.xsd
@@ -14,12 +14,12 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
   jaxb:version="2.0"
-  xmlns="http://collectionspace.org/services/collectionobject/domain/naturalhistory_extension"
-  targetNamespace="http://collectionspace.org/services/collectionobject/domain/naturalhistory_extension"
+  xmlns="http://collectionspace.org/services/collectionobject/domain/naturalhistory"
+  targetNamespace="http://collectionspace.org/services/collectionobject/domain/naturalhistory"
   version="0.1"
 >
   <!-- collection-object for museum of natural history  -->
-  <xs:element name="collectionobjects_naturalhistory_extension">
+  <xs:element name="collectionobjects_naturalhistory">
     <!-- keep old class name -->
     <xs:annotation>
       <xs:appinfo>


### PR DESCRIPTION
**What does this do?**
Retarget the xsd/generated JAXB class to "naturalhistory" to match the live tenants, and update the dependent imports.

**Why are we doing this? (with JIRA link)**
The `collectionobjects_naturalhistory.xsd` targetNamespace/root element was upstream-named `naturalhistory_extension`, but UCBG, UCJEPS, and PAHMA, the only live tenants with a natural-history part, serve it under the legacy `naturalhistory` namespace. The QName mismatch caused JAXB unmarshalling to throw in CollectionObjectMapper, so the taxon field never populated in advancedsearch results: https://collectionspace.atlassian.net/browse/DRYD-2121

**How should this be tested? Do these changes have associated tests?**
Start cspace locally and using ucbg profile: http://localhost:8180/cspace/ucbg :
1. Create a new object with Scientific name set
2. Do an empty search for collection objects and confirm that the "Taxonomic name" column contains the taxon set in step 1.

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally

**Have any new security vulnerabilities been handled?**
no new vulnerabilities introduced